### PR TITLE
don't show the lxqt-leave actions in the "other" section of the menu

### DIFF
--- a/lxqtleave/resources/lxqt-hibernate.desktop.in
+++ b/lxqtleave/resources/lxqt-hibernate.desktop.in
@@ -7,6 +7,6 @@ Exec=lxqt-leave --hibernate
 Icon=system-suspend-hibernate
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt
-NoDisplay=true
+
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-hibernate.desktop.in
+++ b/lxqtleave/resources/lxqt-hibernate.desktop.in
@@ -7,5 +7,6 @@ Exec=lxqt-leave --hibernate
 Icon=system-suspend-hibernate
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt
+NoDisplay=true
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-lockscreen.desktop.in
+++ b/lxqtleave/resources/lxqt-lockscreen.desktop.in
@@ -7,5 +7,6 @@ Exec=lxqt-leave --lockscreen
 Icon=system-lock-screen
 Categories=LXQt;Screensaver
 OnlyShowIn=LXQt;
+NoDisplay=true
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-lockscreen.desktop.in
+++ b/lxqtleave/resources/lxqt-lockscreen.desktop.in
@@ -7,6 +7,6 @@ Exec=lxqt-leave --lockscreen
 Icon=system-lock-screen
 Categories=LXQt;Screensaver
 OnlyShowIn=LXQt;
-NoDisplay=true
+
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-logout.desktop.in
+++ b/lxqtleave/resources/lxqt-logout.desktop.in
@@ -7,6 +7,6 @@ Exec=lxqt-leave --logout
 Icon=system-log-out
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt;
-NoDisplay=true
+
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-logout.desktop.in
+++ b/lxqtleave/resources/lxqt-logout.desktop.in
@@ -7,5 +7,6 @@ Exec=lxqt-leave --logout
 Icon=system-log-out
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt;
+NoDisplay=true
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-reboot.desktop.in
+++ b/lxqtleave/resources/lxqt-reboot.desktop.in
@@ -7,6 +7,6 @@ Exec=lxqt-leave --reboot
 Icon=system-reboot
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt;
-NoDisplay=true
+
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-reboot.desktop.in
+++ b/lxqtleave/resources/lxqt-reboot.desktop.in
@@ -7,5 +7,6 @@ Exec=lxqt-leave --reboot
 Icon=system-reboot
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt;
+NoDisplay=true
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-shutdown.desktop.in
+++ b/lxqtleave/resources/lxqt-shutdown.desktop.in
@@ -7,5 +7,6 @@ Exec=lxqt-leave --shutdown
 Icon=system-shutdown
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt;
+NoDisplay=true
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-shutdown.desktop.in
+++ b/lxqtleave/resources/lxqt-shutdown.desktop.in
@@ -7,6 +7,6 @@ Exec=lxqt-leave --shutdown
 Icon=system-shutdown
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt;
-NoDisplay=true
+
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-suspend.desktop.in
+++ b/lxqtleave/resources/lxqt-suspend.desktop.in
@@ -7,5 +7,6 @@ Exec=lxqt-leave --suspend
 Icon=system-suspend
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt
+NoDisplay=true
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqtleave/resources/lxqt-suspend.desktop.in
+++ b/lxqtleave/resources/lxqt-suspend.desktop.in
@@ -7,6 +7,6 @@ Exec=lxqt-leave --suspend
 Icon=system-suspend
 Categories=LXQt;X-Leave
 OnlyShowIn=LXQt
-NoDisplay=true
+
 
 #TRANSLATIONS_DIR=../translations


### PR DESCRIPTION
this temporarily fixes https://github.com/lxde/lxqt/issues/437 
until we have decided how to handle the lxqt-leave actions
