### PR TITLE
Adjust the positions of buttons in autostart and environment variable settings pages.

### DIFF
--- a/lxqt-config-session/autostartpage.ui
+++ b/lxqt-config-session/autostartpage.ui
@@ -58,19 +58,6 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="1">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="1" column="0" rowspan="5">
     <widget class="QTreeView" name="autoStartView">
      <attribute name="headerVisible">

--- a/lxqt-config-session/environmentpage.ui
+++ b/lxqt-config-session/environmentpage.ui
@@ -11,19 +11,6 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_7">
-   <item row="1" column="1">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>59</width>
-       <height>97</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="2" column="1">
     <widget class="QPushButton" name="addButton">
      <property name="text">


### PR DESCRIPTION
The buttons in autostart and environment variable settings pages are centered vertically, which looks weird.
This commit removed the unused spacer.
@paulolieuthier @jleclanche @luis-pereira please help review. Thanks!