### PR TITLE
lxqt-session: keyboard layout/settings reload after new input device add...

### DIFF
--- a/lxqt-session/CMakeLists.txt
+++ b/lxqt-session/CMakeLists.txt
@@ -4,6 +4,15 @@ if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if(NOT DEFINED LIBUDEV_MONITOR OR LIBUDEV_MONITOR)
+    set(LIBUDEV_MONITOR Yes)
+
+    find_package(PkgConfig)
+    pkg_check_modules(LIBUDEV REQUIRED libudev)
+
+    add_definitions(-DWITH_LIBUDEV_MONITOR)
+endif()
+
 include(LxQtLibSuffix)
 
 include_directories(
@@ -14,6 +23,9 @@ include_directories(
     ${X11_INCLUDE_DIR}
     src
 )
+if(LIBUDEV_MONITOR)
+    include_directories(${LIBUDEV_INCLUDE_DIRS})
+endif()
 
 set(lxqt-session_HDRS "")
 
@@ -25,6 +37,9 @@ set(lxqt-session_SRCS
     src/sessionapplication.cpp
     src/sessiondbusadaptor.h
 )
+if(LIBUDEV_MONITOR)
+    list(APPEND lxqt-session_SRCS src/UdevNotifier.cpp)
+endif()
 
 set(lxqt-session_UI
     src/wmselectdialog.ui
@@ -63,4 +78,8 @@ target_link_libraries(lxqt-session
     ${QTXDG_LIBRARIES}
     KF5::WindowSystem
 )
+if(LIBUDEV_MONITOR)
+    target_link_libraries(lxqt-session ${LIBUDEV_LIBRARIES})
+endif()
+
 INSTALL(TARGETS lxqt-session RUNTIME DESTINATION bin)

--- a/lxqt-session/src/UdevNotifier.cpp
+++ b/lxqt-session/src/UdevNotifier.cpp
@@ -1,0 +1,99 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org
+ *
+ * Copyright: 2015 LXQt team
+ * Authors:
+ *  Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "UdevNotifier.h"
+#include <libudev.h>
+#include <QDebug>
+#include <QSocketNotifier>
+
+
+class UdevNotifier::Impl
+{
+public:
+    struct udev * udev;
+    struct udev_monitor * monitor;
+    QScopedPointer<QSocketNotifier> notifier;
+};
+
+
+UdevNotifier::UdevNotifier(QString const & subsystem, QObject * parent/* = nullptr*/)
+    : QObject(parent)
+    , d(new Impl)
+{
+    d->udev = udev_new();
+    d->monitor = udev_monitor_new_from_netlink(d->udev, "udev");
+    if (nullptr == d->monitor)
+    {
+        qWarning() << QStringLiteral("UdevNotifier: unable to initialize udev_monitor, monitoring will be disabled");
+        return;
+    }
+
+    int ret = udev_monitor_filter_add_match_subsystem_devtype(d->monitor, subsystem.toUtf8().constData(), nullptr);
+    if (0 != ret)
+        qWarning() << QStringLiteral("UdevNotifier: unable to add match subsystem, monitor will receive all devices");
+
+    ret = udev_monitor_enable_receiving(d->monitor);
+    if (0 != ret)
+    {
+        qWarning() << QStringLiteral("UdevNotifier: unable to enable receiving(%1), monitoring will be disabled").arg(ret);
+        return;
+    }
+
+    d->notifier.reset(new QSocketNotifier(udev_monitor_get_fd(d->monitor), QSocketNotifier::Read));
+    connect(d->notifier.data(), &QSocketNotifier::activated, this, &UdevNotifier::eventReady);
+    d->notifier->setEnabled(true);
+}
+
+UdevNotifier::~UdevNotifier()
+{
+    if (d->monitor)
+        udev_monitor_unref(d->monitor);
+    udev_unref(d->udev);
+}
+
+void UdevNotifier::eventReady(int socket)
+{
+    struct udev_device * dev;
+    while (nullptr != (dev = udev_monitor_receive_device(d->monitor)))
+    {
+        QString const action = udev_device_get_action(dev);
+        QString const device = udev_device_get_devpath(dev);
+
+        if (QStringLiteral("add") == action)
+            emit deviceAdded(std::move(device));
+        else if (QStringLiteral("remove") == action)
+            emit deviceRemoved(std::move(device));
+        else if (QStringLiteral("change") == action)
+            emit deviceChanged(std::move(device));
+        else if (QStringLiteral("online") == action)
+            emit deviceOnline(std::move(device));
+        else if (QStringLiteral("offline") == action)
+            emit deviceOffline(std::move(device));
+
+        udev_device_unref(dev);
+    }
+}

--- a/lxqt-session/src/UdevNotifier.h
+++ b/lxqt-session/src/UdevNotifier.h
@@ -1,0 +1,59 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org
+ *
+ * Copyright: 2015 LXQt team
+ * Authors:
+ *  Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#if !defined(UdevNotifier_h)
+#define UdevNotifier_h
+#if defined(WITH_LIBUDEV_MONITOR)
+
+#include <QObject>
+#include <QScopedPointer>
+
+class UdevNotifier : public QObject
+{
+    Q_OBJECT
+public:
+    UdevNotifier(QString const & subsystem, QObject * parent = nullptr);
+    ~UdevNotifier();
+
+signals:
+    void deviceAdded(QString path);
+    void deviceRemoved(QString path);
+    void deviceChanged(QString path);
+    void deviceOnline(QString path);
+    void deviceOffline(QString path);
+
+private slots:
+    void eventReady(int socket);
+
+private:
+    class Impl;
+
+    QScopedPointer<Impl> d;
+};
+
+#endif //WITH_LIBUDEV_MONITOR
+#endif //UdevNotifier_h


### PR DESCRIPTION
...ed

After plugging new keyboard ... udev -> evdev -> xorg resets keyboard settings (layout etc.) based
on /etc/default/keyboard. We need to restore (saved) settings after that.

Monitoring of adding an input device pulls the libudev dependency, but
the whole handling can be disabled by `cmake -DLIBUDEV_MONITOR=no` =>
it's up on the package builder if the new dependency is pulled.