### PR TITLE
Fix some invalid categories and missed main categories

### DIFF
--- a/lxqt-leave/resources/lxqt-hibernate.desktop.in
+++ b/lxqt-leave/resources/lxqt-hibernate.desktop.in
@@ -5,7 +5,7 @@ GenericName=Hibernate
 Comment=hibernate the machine
 Exec=lxqt-leave --hibernate
 Icon=system-suspend-hibernate
-Categories=LXQt;X-Leave
+Categories=System;X-Leave
 OnlyShowIn=LXQt
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqt-leave/resources/lxqt-leave.desktop.in
+++ b/lxqt-leave/resources/lxqt-leave.desktop.in
@@ -5,7 +5,7 @@ GenericName=Leave
 Comment=Leave dialog
 Exec=lxqt-leave
 Icon=system-shutdown
-Categories=LXQt;X-Leave
+Categories=System;X-Leave
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqt-leave/resources/lxqt-lockscreen.desktop.in
+++ b/lxqt-leave/resources/lxqt-lockscreen.desktop.in
@@ -5,7 +5,7 @@ GenericName=Lock Screen
 Comment=Lock the current session
 Exec=lxqt-leave --lockscreen
 Icon=system-lock-screen
-Categories=LXQt;Screensaver
+Categories=System;Screensaver
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqt-leave/resources/lxqt-logout.desktop.in
+++ b/lxqt-leave/resources/lxqt-logout.desktop.in
@@ -5,7 +5,7 @@ GenericName=Logout
 Comment=Logout from the current session
 Exec=lxqt-leave --logout
 Icon=system-log-out
-Categories=LXQt;X-Leave
+Categories=System;X-Leave
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqt-leave/resources/lxqt-reboot.desktop.in
+++ b/lxqt-leave/resources/lxqt-reboot.desktop.in
@@ -5,7 +5,7 @@ GenericName=Reboot
 Comment=reboot the machine
 Exec=lxqt-leave --reboot
 Icon=system-reboot
-Categories=LXQt;X-Leave
+Categories=System;X-Leave
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqt-leave/resources/lxqt-shutdown.desktop.in
+++ b/lxqt-leave/resources/lxqt-shutdown.desktop.in
@@ -5,7 +5,7 @@ GenericName=Shutdown
 Comment=shutdown the machine
 Exec=lxqt-leave --shutdown
 Icon=system-shutdown
-Categories=LXQt;X-Leave
+Categories=System;X-Leave
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=../translations

--- a/lxqt-leave/resources/lxqt-suspend.desktop.in
+++ b/lxqt-leave/resources/lxqt-suspend.desktop.in
@@ -5,7 +5,7 @@ GenericName=Suspend
 Comment=suspend the machine
 Exec=lxqt-leave --suspend
 Icon=system-suspend
-Categories=LXQt;X-Leave
+Categories=System;X-Leave
 OnlyShowIn=LXQt
 
 #TRANSLATIONS_DIR=../translations


### PR DESCRIPTION
System is a main category, no visible and fuctional changes
W: lxqt-session: desktop-entry-invalid-category LXQt lxqt-\*.desktop
W: lxqt-session: desktop-entry-lacks-main-category lxqt-\*.desktop