### PR TITLE
Fix typos in lxqt-config-session and lxqt-config manpages

### DIFF
--- a/lxqt-config-session/man/lxqt-config-session.1
+++ b/lxqt-config-session/man/lxqt-config-session.1
@@ -1,15 +1,15 @@
-.TH lxqt-config-session "1" "September 2012" "LXQt\ 0.7.0" "LXQt\ Application"
+.TH lxqt-config-session "1" "October 2015" "LXQt\ 0.9.0" "LXQt\ Application"
 .SH NAME
-lxqt-config-session \- Session settings of \fBLXQt\fR, the Lightweight Desktop Environment
+\fBlxqt-config-session\fR \- Session settings of \fBLXQt\fR, the Lightweight Desktop Environment
 .SH SYNOPSIS
 .B lxqt-config-session
 .br
 .SH DESCRIPTION
-This application handle settings and configurations around autostart applications  on \fBLXQt\-qt\fR desktop environment.
+This application handle settings and configuration around autostart applications on \fBLXQt\fR desktop environment.
 .P
-Through this applicaton you can manage settings related to applications startup and LXQt modules.
+Through this applicaton you can manage settings related to applications startup and \fBLXQt\fR modules.
 .P
-\fBLXQt\-qt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt
+\fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt
 technologies, ships several core desktop components, all of which are optional:
 .P
  * Panel
@@ -18,7 +18,7 @@ technologies, ships several core desktop components, all of which are optional:
  * Settings center
  * Session handler \fI(related to this)\fR
  * Polkit handler
- * SSYH password access
+ * SSH password access
  * Display manager handler
 .P
 These components perform similar actions to those available in other desktop
@@ -26,17 +26,17 @@ environments, and their names are self-descriptive.  They are usually not launch
 by hand but automatically, when choosing a \fBLXQt\fR session in the Display
 Manager.
 .SH "REPORTING BUGS"
-Report bugs to https://github.com/LXQt/LXQt/issues
+Report bugs to https://github.com/lxde/lxqt/issues
 .SH "SEE ALSO"
-LXQt it has been tailored for users who value simplicity, speed, and
+\fBLXQt\fR has been tailored for users who value simplicity, speed, and
 an intuitive interface, also intended for less powerful machines. See:
 .\" any module must refers to session app, for more info on start it
 .P
-\fBlxqt-config.1\fR  LXQt application for manage configurations and settings
+\fBlxqt-config(1)\fR  \fBLXQt\fR application to manage configuration and settings
 .P
-\fBlxqt-session.1\fR  LXQt module for manage LXQt autostart session applications
-.P
-\fBstart-lxqt.1\fR  LXQt display management independient starup.
+\fBlxqt-session(1)\fR  \fBLXQt\fR module to manage \fBLXQt\fR autostart session applications
+\".P
+\"\fBstart-lxqt(1)\fR  \fBLXQt\fR display manager independent startup.
 .P
 .SH AUTHOR
 This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR

--- a/lxqt-config-session/translations/lxqt-config-session_cs.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_cs.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[cs]=Nastavit modul sezení LXQt-Qt
-GenericName[cs]=Nastavení sezení LXQt-Qt
-Name[cs]=Nastavení sezení LXQt-Qt
+Comment[cs]=Nastavit modul sezení LXQt
+GenericName[cs]=Nastavení sezení LXQt
+Name[cs]=Nastavení sezení LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_da.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_da.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[da]=Indstil LXQt-Qt Sessionsmodul
+Comment[da]=Indstil LXQt Sessionsmodul
 GenericName[da]=Indstilling af LXQt-sessioner
 Name[da]=Indstilling af LXQt-sessioner

--- a/lxqt-config-session/translations/lxqt-config-session_da_DK.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_da_DK.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[da_DK]=Indstilling af LXQt-Qt sessionsmodul
+Comment[da_DK]=Indstilling af LXQt sessionsmodul
 GenericName[da_DK]=Indstilling af LXQt Session
 Name[da_DK]=Indstilling af LXQt Session

--- a/lxqt-config-session/translations/lxqt-config-session_eo.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_eo.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[eo]=Agordi modulon de seanco de LXQt-Qt
+Comment[eo]=Agordi modulon de seanco de LXQt
 GenericName[eo]=Agordilo de seanco de LXQt
 Name[eo]=Agordilo de seanco de LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_es.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_es.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[es]=Configura el módulo de sesiones de LXQt-Qt
+Comment[es]=Configura el módulo de sesiones de LXQt
 GenericName[es]=Configuración de sesiones LXQt
 Name[es]=Configuración de sesiones LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_es_VE.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_es_VE.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[es_VE]=Configuracion de modulo de LXQt-Qt
+Comment[es_VE]=Configuracion de modulo de LXQt
 GenericName[es_VE]=Configuracion de sesion de LXQt
 Name[es_VE]=Configuracion de sesion de LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_eu.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_eu.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[eu]=Konfiguratu LXQt-Qt saioaren modulua
+Comment[eu]=Konfiguratu LXQt saioaren modulua
 GenericName[eu]=LXQt saioaren konfiguratzailea
 Name[eu]=LXQt saioaren konfiguratzailea

--- a/lxqt-config-session/translations/lxqt-config-session_fi.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_fi.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[fi]=Hallinnoi LXQt-Qt:n istuntomoduulia
+Comment[fi]=Hallinnoi LXQt:n istuntomoduulia
 GenericName[fi]=LXQtin istunnonhallinta
 Name[fi]=LXQtin istunnonhallinta

--- a/lxqt-config-session/translations/lxqt-config-session_fr_FR.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_fr_FR.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[fr_FR]=Configurer le module 'session' de LXQt-Qt
+Comment[fr_FR]=Configurer le module 'session' de LXQt
 GenericName[fr_FR]=Paramétreur de session LXQt
 Name[fr_FR]=Paramétreur de session LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_hu.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_hu.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[hu]=A LXQt-Qt munkamenetmodul beállítása
+Comment[hu]=A LXQt munkamenetmodul beállítása
 GenericName[hu]=LXQt munkamenetbeállíó
 Name[hu]=LXQt munkamenetbeállíó

--- a/lxqt-config-session/translations/lxqt-config-session_id_ID.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_id_ID.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[id_ID]=Konfigurasi modul sesi LXQt-Qt
+Comment[id_ID]=Konfigurasi modul sesi LXQt
 GenericName[id_ID]=Konfigurator Sesi LXQt
 Name[id_ID]=Konfigurator Sesi LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_ja.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_ja.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[ja]=LXQt-Qtセッションもジュールを設定
+Comment[ja]=LXQtセッションもジュールを設定
 GenericName[ja]=LXQtセッションの設定
 Name[ja]=LXQtセッションの設定

--- a/lxqt-config-session/translations/lxqt-config-session_lt.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_lt.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[lt]=Konfigūruoti LXQt-Qt sesijų modulį
+Comment[lt]=Konfigūruoti LXQt sesijų modulį
 GenericName[lt]=LXQt sesijų konfigūravimas
 Name[lt]=LXQt sesijų konfigūravimas

--- a/lxqt-config-session/translations/lxqt-config-session_nl.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_nl.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[nl]=Configureer LXQt-Qt sessie module
+Comment[nl]=Configureer LXQt sessie module
 GenericName[nl]=LXQt sessie Configurator
 Name[nl]=LXQt sessie Configurator

--- a/lxqt-config-session/translations/lxqt-config-session_pl.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_pl.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[pl]=Ustawienia sesji LXQt-Qt
+Comment[pl]=Ustawienia sesji LXQt
 GenericName[pl]=Ustawienia sesji LXQt
 Name[pl]=Ustawienia sesji LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_pt_BR.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_pt_BR.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[pt_BR]=Módulo de configurador de sessão do LXQt-Qt
+Comment[pt_BR]=Módulo de configurador de sessão do LXQt
 GenericName[pt_BR]=Configurador de sessão do LXQt
 Name[pt_BR]=Configurador de sessão do LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_ro_RO.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_ro_RO.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[ro_RO]=Configurează modulul sesiune LXQt-Qt
+Comment[ro_RO]=Configurează modulul sesiune LXQt
 GenericName[ro_RO]=Configurare sesiune LXQt
 Name[ro_RO]=Configurare sesiune LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_sk.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_sk.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[sk]=Nastavenie relácie prostredia LXQt-Qt
+Comment[sk]=Nastavenie relácie prostredia LXQt
 GenericName[sk]=Nastavenie relácie prostredia LXQt
 Name[sk]=Nastavenie relácie

--- a/lxqt-config-session/translations/lxqt-config-session_th_TH.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_th_TH.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[th_TH]=ตั้งค่ามอดูลวาระงาน LXQt-Qt
+Comment[th_TH]=ตั้งค่ามอดูลวาระงาน LXQt
 GenericName[th_TH]=ตัวตั้งค่าวาระงาน LXQt
 Name[th_TH]=ตัวตั้งค่าวาระงาน LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_tr.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_tr.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[tr]=LXQt-Qt oturum modülünü yapılandır
+Comment[tr]=LXQt oturum modülünü yapılandır
 GenericName[tr]=LXQt Oturum Yapılandırıcı
 Name[tr]=LXQt Oturum Yapılandırıcı

--- a/lxqt-config-session/translations/lxqt-config-session_uk.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_uk.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[uk]=Налаштувати модуль сеансу LXQt-Qt
+Comment[uk]=Налаштувати модуль сеансу LXQt
 GenericName[uk]=Налаштування сеансу LXQt
 Name[uk]=Налаштування сеансу LXQt

--- a/lxqt-config-session/translations/lxqt-config-session_zh_CN.desktop
+++ b/lxqt-config-session/translations/lxqt-config-session_zh_CN.desktop
@@ -1,4 +1,4 @@
 # Translations
-Comment[zh_CN]=配置 LXQt-Qt 会话模块
+Comment[zh_CN]=配置 LXQt 会话模块
 GenericName[zh_CN]=LXQt 会话配置
 Name[zh_CN]=LXQt 会话配置

--- a/lxqt-leave/translations/lxqt-lockscreen_fr.desktop
+++ b/lxqt-leave/translations/lxqt-lockscreen_fr.desktop
@@ -1,0 +1,3 @@
+Comment[fr]=Verrouillage de la session courante
+GenericName[fr]=Verrouiller l’écran
+Name[fr]=Verrouiller l’écran

--- a/lxqt-session/man/lxqt-session.1
+++ b/lxqt-session/man/lxqt-session.1
@@ -1,11 +1,11 @@
-.TH lxqt-session "1" "September 2012" "LXQt\ 0.7.0" "LXQt\ Module"
+.TH lxqt-session "1" "October 2015" "LXQt\ 0.9.0" "LXQt\ Module"
 .SH NAME
-lxqt-session \- Session manager of \fBLXQt\fR, the Lightweight Desktop Environment
+\fBlxqt-session\fR \- Session manager of \fBLXQt\fR, the Lightweight Desktop Environment
 .SH SYNOPSIS
 .B lxqt-session
 .br
 .SH DESCRIPTION
-This module handle session autostart application over \fBLXQt\fR desktop environment startup.
+This module handles session autostart application over \fBLXQt\fR desktop environment startup.
 .P
 The \fBLXQt modules\fR are desktop independent tools,
 and operate as daemons for the local user for desktop specific operations.
@@ -23,28 +23,28 @@ and operate as daemons for the local user for desktop specific operations.
 .P
 These components perform similar actions to those available in other desktop
 environments, and their names are self-descriptive.  They are usually not launched
-by hand but automatically, when choosing a \fBLXQt\-qt\fR session in the Display
+by hand but automatically, when choosing a \fBLXQt\fR session in the Display
 Manager.
 .SH BEHAVIOR
 Through this application \fBLXQt\fR desktop environment manage the session desktop behavior,
-module loading and related starup programs before user gets a working area. By default this module
-load the panel, desktop and power modules of \fBLXQt\fR environment, such then this its a
-important module for a working lxqt sesion.
+module loading and related startup programs before user gets a working area. By default this module
+loads the panel, desktop and power modules of \fBLXQt\fR environment, thus it is an
+important module for a working \fBLXQt\fR session.
 .P
 Each of any desktop environment has any way to configure applications need or want to start at logon,
-so user can manage manualy in the \fBlxqt-config-session\fR application.
+so user can manage manually in the \fBlxqt-config-session\fR application.
 .SH "REPORTING BUGS"
 Report bugs to https://github.com/lxde/lxqt/issues
 .SH "SEE ALSO"
-\fBLXQt\fR it has been tailored for users who value simplicity, speed, and
+\fBLXQt\fR has been tailored for users who value simplicity, speed, and
 an intuitive interface, also intended for less powerful machines. See also:
 .\" any module must refers to session app, for more info on start it
 .P
-\fBlxqt-config.1\fR  LXQt application for manage configurations and settings
+\fBlxqt-config(1)\fR  \fBLXQt\fR application to manage configuration and settings
 .P
-\fBlxqt-config-session.1\fR  LXQt module for manage LXQt autostart session applications
-.P
-\fBstart-lxqt.1\fR  LXQt display management independient starup.
+\fBlxqt-config-session(1)\fR  \fBLXQt\fR module to manage \fBLXQt\fR autostart session applications
+\".P
+\"\fBstart-lxqt(1)\fR  LXQt display management independient starup.
 .P
 .SH AUTHOR
 This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR


### PR DESCRIPTION
Section “SEE ALSO” of lxqt-config-session and lxqt-session manpage does
reference three other manpages: lxqt-session(1) is currently shipped
with LXQt, lxqt-config(1) is present on git repository but not currently
shipped (on Debian at least) and the last one – start-lxqt(1) – doesn’t
exist at the moment, which is why it has been commented out.

Fix use of bold font in lxqt-config-session manpage

Replace LXQt-Qt with LXQt in lxqt-config-session desktop file