### PR TITLE
lxqt-session: Update man pages and make session the overview

### DIFF
--- a/lxqt-config-session/man/lxqt-config-session.1
+++ b/lxqt-config-session/man/lxqt-config-session.1
@@ -1,43 +1,20 @@
-.TH lxqt-config-session "1" "October 2015" "LXQt\ 0.9.0" "LXQt\ Application"
+.TH lxqt-config-session "1" "2015-11-05" "LXQt 0.10.0" "LXQt Application/Environment Configuration"
 .SH NAME
-\fBlxqt-config-session\fR \- Session settings of \fBLXQt\fR, the Lightweight Desktop Environment
+\fBlxqt-config-session\fR \- Application settings of \fBLXQt\fR: The Lightweight
+Qt Desktop Environment
 .SH SYNOPSIS
 .B lxqt-config-session
 .br
 .SH DESCRIPTION
-This application handle settings and configuration around autostart applications on \fBLXQt\fR desktop environment.
-.P
-Through this applicaton you can manage settings related to applications startup and \fBLXQt\fR modules.
-.P
-\fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on Qt
-technologies, ships several core desktop components, all of which are optional:
-.P
- * Panel
- * Desktop
- * Application launcher
- * Settings center
- * Session handler \fI(related to this)\fR
- * Polkit handler
- * SSH password access
- * Display manager handler
-.P
-These components perform similar actions to those available in other desktop
-environments, and their names are self-descriptive.  They are usually not launched
-by hand but automatically, when choosing a \fBLXQt\fR session in the Display
-Manager.
+This application handles \fBLXQt\fR default applications settings, autostart
+configuration, and environment settings.
 .SH "REPORTING BUGS"
 Report bugs to https://github.com/lxde/lxqt/issues
 .SH "SEE ALSO"
-\fBLXQt\fR has been tailored for users who value simplicity, speed, and
-an intuitive interface, also intended for less powerful machines. See:
-.\" any module must refers to session app, for more info on start it
+.\" any module must refer to the session application, for module overview and initiation
+\fBstartlxqt.1\fR  LXQt session initialization and launch script (e.g. in \fB.xinitrc\fR)
 .P
-\fBlxqt-config(1)\fR  \fBLXQt\fR application to manage configuration and settings
+\fBlxqt-session.1\fR  LXQt \fIoverview\fR and complete session environment
 .P
-\fBlxqt-session(1)\fR  \fBLXQt\fR module to manage \fBLXQt\fR autostart session applications
-\".P
-\"\fBstart-lxqt(1)\fR  \fBLXQt\fR display manager independent startup.
+\fBlxqt-config.1\fR  LXQt settings Configuration Center interface
 .P
-.SH AUTHOR
-This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR
-for \fBLXQt\fR project and VENENUX GNU/Linux but can be used by others.

--- a/lxqt-leave/resources/lxqt-leave.1
+++ b/lxqt-leave/resources/lxqt-leave.1
@@ -1,10 +1,13 @@
-.TH lxqt-leave 1 "" "" "LXQt\ Helper"
+.TH lxqt-leave 1 "2015-11-05" "LXQt 0.10.0" "LXQt Leave Session Module"
 .SH NAME
-\fBlxqt-leave\fR \- easily logout, reboot, shutdown, suspend, hibernate and lock screen from a dialog
+\fBlxqt-leave\fR \- Dialog to easily select logout, reboot, shutdown,
+suspend, hibernate, and lock screen
 .SH SYNOPSIS
 \fBlxqt-leave\fR [\fIargument\fR]
 .SH DESCRIPTION
-\fBlxqt-leave\fR is a graphical Qt tool for easily triggering leave session actions: logout, reboot, shutdown, hibernate and lock screen. If run with an argument, the dialog is not shown and the action is executed directly.
+\fBlxqt-leave\fR is a graphical Qt tool for easily triggering leave session
+actions: logout, reboot, shutdown, hibernate, and lock screen. If run with
+an argument, the dialog is not shown and the action is executed directly.
 .SH OPTIONS
 .PP
 The options which apply to the \fBlxqt-leave\fR command are:
@@ -31,5 +34,16 @@ The options which apply to the \fBlxqt-leave\fR command are:
 .RE
 .SH "REPORTING BUGS"
 Report bugs to https://github.com/lxde/lxqt/issues
+.SH "SEE ALSO"
+.\" any module must refer to the session application, for module overview and initiation
+\fBstartlxqt.1\fR  LXQt session initialization and launch script (e.g. in \fB.xinitrc\fR)
+.P
+\fBlxqt-session.1\fR  LXQt \fIoverview\fR and complete session environment
+.P
+\fBlxqt-config-session.1\fR  LXQt default and autostart applications settings,
+plus environment settings
+.P
+\fBlxqt-config.1\fR  LXQt settings Configuration Center interface
+.P
 .SH AUTHOR
 This manual page was created by \fBPaulo Lieuthier\fR \fI<paulolieuthier@gmail.com>\fR for the \fBLXQt\fR project.

--- a/lxqt-session/man/lxqt-session.1
+++ b/lxqt-session/man/lxqt-session.1
@@ -1,51 +1,65 @@
-.TH lxqt-session "1" "October 2015" "LXQt\ 0.9.0" "LXQt\ Module"
+.TH lxqt-session "1" "2015-11-05" "LXQt 0.10.0" "LXQt Session Module"
 .SH NAME
-\fBlxqt-session\fR \- Session manager of \fBLXQt\fR, the Lightweight Desktop Environment
+\fBlxqt-session\fR \- Session manager of \fBLXQt\fR: The Lightweight Qt Desktop
+Environment
 .SH SYNOPSIS
 .B lxqt-session
 .br
 .SH DESCRIPTION
-This module handles session autostart application over \fBLXQt\fR desktop environment startup.
+This module handles session autostart application over \fBLXQt\fR desktop
+environment startup.
 .P
-The \fBLXQt modules\fR are desktop independent tools,
-and operate as daemons for the local user for desktop specific operations.
+The \fBLXQt modules\fR are desktop independent tools, and operate as daemons
+for the local user on desktop specific operations.
 .P
-\fBLXQt\fR ships several core desktop components, all of which are optional:
+\fBLXQt\fR is an advanced, easy-to-use, and fast desktop environment based on
+the Qt framework. It has been tailored for users who value simplicity, speed,
+and an intuitive interface, with minimal resource requirements. It comprises
+several optional desktop components:
 .P
- * Panel
- * Desktop
+ * Session module (\fIthis\fR, normally invoked with \fBstartlxqt\fR)
+ * Settings configuration center
  * Application launcher
- * Settings center
- * Session handler \fI(this)\fR
- * Polkit handler
+ * Desktop
+ * Panel with optional plugins
+ * Polkit authorization agent
  * SSH password access
- * Display manager handler
+ * Display manager module
+ * Power management module
+ * Sudo/su module (privilege elevation)
 .P
 These components perform similar actions to those available in other desktop
-environments, and their names are self-descriptive.  They are usually not launched
-by hand but automatically, when choosing a \fBLXQt\fR session in the Display
-Manager.
+environments, and their name is self-descriptive.  They are usually launched
+automatically, when choosing a \fBLXQt\fR session in the Display Manager.
 .SH BEHAVIOR
-Through this application \fBLXQt\fR desktop environment manage the session desktop behavior,
-module loading and related startup programs before user gets a working area. By default this module
-loads the panel, desktop and power modules of \fBLXQt\fR environment, thus it is an
-important module for a working \fBLXQt\fR session.
-.P
-Each of any desktop environment has any way to configure applications need or want to start at logon,
-so user can manage manually in the \fBlxqt-config-session\fR application.
+This application manages the \fBLXQt\fR session desktop behavior, module
+loading, and related startup programs prior loading the user workspace.
+By default this module loads the panel, desktop, and power management
+modules, thus it is important for a working \fBLXQt\fR session.
+.SH AUTOSTART
+The modules are only shown by default in the \fBLXQt\fR desktop environment, but
+an autostart action can be created for other preferred desktop environments.
 .SH "REPORTING BUGS"
-Report bugs to https://github.com/lxde/lxqt/issues
+Report bugs to https://github.com/LXDE/LXQt/issues
 .SH "SEE ALSO"
-\fBLXQt\fR has been tailored for users who value simplicity, speed, and
-an intuitive interface, also intended for less powerful machines. See also:
-.\" any module must refers to session app, for more info on start it
+.\" any module must refer to the session application, for module overview and initiation
+\fBstartlxqt.1\fR  LXQt session initialization and launch script (e.g. in \fB.xinitrc\fR)
 .P
-\fBlxqt-config(1)\fR  \fBLXQt\fR application to manage configuration and settings
+\fBlxqt-config-session.1\fR  LXQt default and autostart applications settings,
+plus environment settings
 .P
-\fBlxqt-config-session(1)\fR  \fBLXQt\fR module to manage \fBLXQt\fR autostart session applications
-\".P
-\"\fBstart-lxqt(1)\fR  LXQt display management independient starup.
+\fBlxqt-config.1\fR  LXQt settings Configuration Center interface
 .P
-.SH AUTHOR
-This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR
-for \fBLXQt\fR project and VENENUX GNU/Linux but can be used by others.
+\fBlxqt-leave.1\fR  LXQt session logout, reboot, shutdown, suspend, hibernate
+and lock screen
+.P
+\fBlxqt-openssh-askpass.1\fR  LXQt password access over ssh cryptography toolkit
+.P
+\fBlxqt-panel.1\fR  LXQt desktop panel with optional plugins
+.P
+\fBlxqt-policykit-agent.1\fR  LXQt polkit authorization agent
+.P
+\fBlxqt-runner.1\fR  LXQt application launcher by keyboard shortcut
+.P
+\fBlxqt-sudo.1\fR  LXQt sudo/su GUI for application privilege elevation
+.P


### PR DESCRIPTION
Per the previous discussions in and related to https://github.com/lxde/lxqt-panel/pull/271, I've now made lxqt-session.1 include the LXQt module overview (which all the old man pages already state, actually), and simplified the remainder, trying to make them consistent.  I've also now similarly updated and rebased the lxqt-panel.1 in the above link.  I've tried my best to discern better descriptions of the modules, but you devs obviously know them better.  :)