### PR TITLE
CMakeLists.txt: Add cmake minimum required version

### DIFF
--- a/lxqt-session/CMakeLists.txt
+++ b/lxqt-session/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 project(lxqt-session)
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Required by CMP0000 policy. Version 3.0.2 was chosen because
lxqt-session's dependency liblxqt requires it explicitly.

Signed-off-by: Ioan-Adrian Ratiu <adi@adirat.com>