### PR TITLE
Fix ending session and stopping modules

### DIFF
--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -329,7 +329,7 @@ void LXQtModuleManager::logout()
     {
         i.next();
         LXQtModule* p = i.value();
-        if (p->state() != QProcess::NotRunning && !p->waitForFinished())
+        if (p->state() != QProcess::NotRunning && !p->waitForFinished(2000))
         {
             qWarning() << QString("Module '%1' won't terminate ... killing.").arg(i.key());
             p->kill();
@@ -337,7 +337,7 @@ void LXQtModuleManager::logout()
     }
 
     mWmProcess->terminate();
-    if (mWmProcess->state() != QProcess::NotRunning && !mWmProcess->waitForFinished())
+    if (mWmProcess->state() != QProcess::NotRunning && !mWmProcess->waitForFinished(2000))
     {
         qWarning() << QString("Window Manager won't terminate ... killing.");
         mWmProcess->kill();

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -23,6 +23,7 @@
 #include "UdevNotifier.h"
 #include "numlock.h"
 #include <unistd.h>
+#include <csignal>
 #include <LXQt/Settings>
 #include <QProcess>
 #include <QDebug>
@@ -33,6 +34,7 @@
 
 SessionApplication::SessionApplication(int& argc, char** argv) : LXQt::Application(argc, argv)
 {
+    listenToUnixSignals({SIGINT, SIGTERM, SIGQUIT, SIGHUP});
     char* winmanager = NULL;
     int c;
     while ((c = getopt (argc, argv, "c:w:")) != -1)
@@ -56,6 +58,7 @@ SessionApplication::SessionApplication(int& argc, char** argv) : LXQt::Applicati
     qputenv("LXQT_SESSION_CONFIG", configName.toUtf8());
 
     modman = new LXQtModuleManager(winmanager);
+    connect(this, &LXQt::Application::unixSignal, modman, &LXQtModuleManager::logout);
     new SessionDBusAdaptor(modman);
     // connect to D-Bus and register as an object:
     QDBusConnection::sessionBus().registerService("org.lxqt.session");


### PR DESCRIPTION
In case lxqt-session is ended others than requesting logout by DBus call, all modules were
shot down by SIGKILL in LXQtModuleManager destruction time. This was resulting into e.g.
pcmafm-qt not saving it's settings -> lxde/lxqt#874 if "desktop" module was enabled.