### PR TITLE
leave: ask or not for confirmation from main dialog

### DIFF
--- a/lxqt-leave/leavedialog.cpp
+++ b/lxqt-leave/leavedialog.cpp
@@ -31,6 +31,7 @@ LeaveDialog::LeaveDialog(QWidget* parent)
     : QDialog(parent, Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint),
     ui(new Ui::LeaveDialog),
     mPower(new LXQt::Power(this)),
+    mPowerManager(new LXQt::PowerManager(this)),
     mScreensaver(new LXQt::ScreenSaver(this))
 {
     ui->setupUi(this);
@@ -72,11 +73,12 @@ LeaveDialog::LeaveDialog(QWidget* parent)
     for (int i = 0; i < N; ++i)
         buttons.at(i)->setMinimumWidth(maxWidth);
 
-    connect(ui->logoutButton,       &QPushButton::clicked, [&] { close(); mPower->logout(); });
-    connect(ui->rebootButton,       &QPushButton::clicked, [&] { close(); mPower->reboot(); });
-    connect(ui->shutdownButton,     &QPushButton::clicked, [&] { close(); mPower->shutdown(); });
-    connect(ui->suspendButton,      &QPushButton::clicked, [&] { close(); mPower->suspend(); });
-    connect(ui->hibernateButton,    &QPushButton::clicked, [&] { close(); mPower->hibernate(); });
+    connect(ui->logoutButton,       &QPushButton::clicked, [&] { close(); mPowerManager->logout();    });
+    connect(ui->rebootButton,       &QPushButton::clicked, [&] { close(); mPowerManager->reboot();    });
+    connect(ui->shutdownButton,     &QPushButton::clicked, [&] { close(); mPowerManager->shutdown();  });
+    connect(ui->suspendButton,      &QPushButton::clicked, [&] { close(); mPowerManager->suspend();   });
+    connect(ui->hibernateButton,    &QPushButton::clicked, [&] { close(); mPowerManager->hibernate(); });
+    connect(ui->cancelButton,       &QPushButton::clicked, [&] { close();                             });
     connect(ui->lockscreenButton,   &QPushButton::clicked, [&] {
         close();
         QEventLoop loop;
@@ -85,7 +87,6 @@ LeaveDialog::LeaveDialog(QWidget* parent)
         loop.exec();
     });
 
-    connect(ui->cancelButton, &QPushButton::clicked, [&] { close(); });
 }
 
 LeaveDialog::~LeaveDialog()

--- a/lxqt-leave/leavedialog.h
+++ b/lxqt-leave/leavedialog.h
@@ -33,6 +33,7 @@
 #include <QDialog>
 #include <QDesktopWidget>
 #include <LXQt/Power>
+#include <LXQt/PowerManager>
 #include <LXQt/ScreenSaver>
 
 namespace Ui {
@@ -52,7 +53,11 @@ protected:
 
 private:
     Ui::LeaveDialog *ui;
+    // LXQt::Power is used to know if the actions are doable, while
+    // LXQt::PowerManager is used to trigger the actions, while
+    // obeying the user option to ask or not for confirmation
     LXQt::Power *mPower;
+    LXQt::PowerManager *mPowerManager;
     LXQt::ScreenSaver *mScreensaver;
 };
 


### PR DESCRIPTION
LXQt::PowerManager reads session settings to decide whether or not ask for confirmation, so let's use it instead of calling LXQt::Power directly.

Fixes lxde/lxqt#855.