### PR TITLE
Add logic to lock screen before system sleeps

### DIFF
--- a/lxqt-session/CMakeLists.txt
+++ b/lxqt-session/CMakeLists.txt
@@ -32,6 +32,8 @@ set(lxqt-session_SRCS
     src/windowmanager.cpp
     src/sessionapplication.cpp
     src/sessiondbusadaptor.h
+    src/lockscreenmanager.cpp
+    src/lockscreenmanager.h
     src/numlock.cpp
     src/numlock.h
     src/log.cpp

--- a/lxqt-session/src/lockscreenmanager.cpp
+++ b/lxqt-session/src/lockscreenmanager.cpp
@@ -1,0 +1,245 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org/
+ *
+ * Copyright: 2016 LXQt team
+ * Authors:
+ *   Paulo Lieuthier <paulolieuthier@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "lockscreenmanager.h"
+#include <QTimer>
+#include <QDBusReply>
+#include <QDebug>
+#include <unistd.h>
+
+LockScreenManager::LockScreenManager(QObject *parent) :
+    QObject(parent)
+{
+}
+
+LockScreenManager::~LockScreenManager()
+{
+    delete mProvider;
+}
+
+bool LockScreenManager::startup()
+{
+    connect(&mScreenSaver, &LXQt::ScreenSaver::done,
+            &mLoop, &QEventLoop::quit);
+
+    mProvider = new LogindProvider;
+    if (!mProvider->isValid())
+    {
+        mProvider->deleteLater();
+        mProvider = new ConsoleKit2Provider;
+        if (!mProvider->isValid())
+        {
+            mProvider->deleteLater();
+            mProvider = nullptr;
+        }
+    }
+
+    if (mProvider)
+    {
+        connect(mProvider,
+                &LockScreenProvider::aboutToSleep,
+                [this] (bool beforeSleep)
+        {
+            if (beforeSleep)
+            {
+                mScreenSaver.lockScreen();
+                mLoop.exec();
+                mProvider->release();
+            }
+            else
+                mProvider->inhibit();
+        });
+
+        connect(mProvider, &LockScreenProvider::lockRequested, [this] {
+            mScreenSaver.lockScreen();
+            mLoop.exec();
+        });
+
+        return mProvider->inhibit();
+    }
+
+    return false;
+}
+
+/*
+ * Logind Provider
+ */
+
+LogindProvider::LogindProvider() :
+    mInterface(QStringLiteral("org.freedesktop.login1"),
+            QStringLiteral("/org/freedesktop/login1"),
+            QStringLiteral("org.freedesktop.login1.Manager"),
+            QDBusConnection::systemBus())
+{
+    if (mInterface.isValid())
+    {
+        connect(&mInterface, SIGNAL(PrepareForSleep(bool)),
+                this, SIGNAL(aboutToSleep(bool)));
+
+        QString sessionId = QDBusInterface(
+                QStringLiteral("org.freedesktop.login1"),
+                QStringLiteral("/org/freedesktop/login1/session/self"),
+                QStringLiteral("org.freedesktop.login1.Session"),
+                QDBusConnection::systemBus())
+            .property("Id").toString();
+
+        // listen to Lock signal as well
+        mInterface.connection().connect(
+                QStringLiteral("org.freedesktop.login1"),
+                QStringLiteral("/org/freedesktop/login1/session/") + sessionId,
+                QStringLiteral("org.freedesktop.login1.Session"),
+                QStringLiteral("Lock"),
+                this,
+                SIGNAL(lockRequested()));
+    }
+}
+
+LogindProvider::~LogindProvider()
+{
+    release();
+}
+
+bool LogindProvider::isValid()
+{
+    return mInterface.isValid();
+}
+
+bool LogindProvider::inhibit()
+{
+    if (mFileDescriptor.isValid())
+        return false;
+
+    QDBusReply<QDBusUnixFileDescriptor> reply = mInterface.call(
+            QStringLiteral("Inhibit"),
+            QStringLiteral("sleep"),
+            QStringLiteral("LXQt Session"),
+            QStringLiteral("Start screen locker before sleep."),
+            QStringLiteral("delay"));
+
+    if (!reply.isValid())
+    {
+        qDebug() << "LockScreenManager: " << reply.error();
+        return false;
+    }
+
+    mFileDescriptor = reply.value();
+    return true;
+}
+
+void LogindProvider::release()
+{
+    if (mFileDescriptor.isValid())
+    {
+        ::close(mFileDescriptor.fileDescriptor());
+        mFileDescriptor.setFileDescriptor(-1);
+    }
+}
+
+/*
+ * ConsoleKit2 provider
+ */
+
+ConsoleKit2Provider::ConsoleKit2Provider() :
+    mInterface(QStringLiteral("org.freedesktop.ConsoleKit"),
+            QStringLiteral("/org/freedesktop/ConsoleKit/Manager"),
+            QStringLiteral("org.freedesktop.ConsoleKit.Manager"),
+            QDBusConnection::systemBus()),
+    mMethodInhibitPresent(false)
+
+{
+    // validate interface, look for melhod Inhibit
+    if (mInterface.isValid())
+    {
+        // this is needed to differentiate ConsoleKit2 from ConsoleKit
+        QDBusReply<QString> reply = QDBusInterface(
+                QStringLiteral("org.freedesktop.ConsoleKit"),
+                QStringLiteral("/org/freedesktop/ConsoleKit/Manager"),
+                QStringLiteral("org.freedesktop.DBus.Introspectable"),
+                QDBusConnection::systemBus())
+            .call(QStringLiteral("Introspect"));
+        mMethodInhibitPresent = reply.value().contains("Inhibit");
+
+        if (mMethodInhibitPresent)
+        {
+            connect(&mInterface, SIGNAL(PrepareForSleep(bool)),
+                    this, SIGNAL(aboutToSleep(bool)));
+
+            QDBusReply<QDBusObjectPath> sessionObjectPath = mInterface
+                .call("GetCurrentSession");
+
+            // listen to Lock signal as well
+            mInterface.connection().connect(
+                    QStringLiteral("org.freedesktop.ConsoleKit"),
+                    sessionObjectPath.value().path(),
+                    QStringLiteral("org.freedesktop.ConsoleKit.Session"),
+                    QStringLiteral("Lock"),
+                    this,
+                    SIGNAL(lockRequested()));
+        }
+    }
+}
+
+ConsoleKit2Provider::~ConsoleKit2Provider()
+{
+    release();
+}
+
+bool ConsoleKit2Provider::isValid()
+{
+    return mInterface.isValid() && mMethodInhibitPresent;
+}
+
+bool ConsoleKit2Provider::inhibit()
+{
+    if (mFileDescriptor.isValid())
+        return false;
+
+    QDBusReply<QDBusUnixFileDescriptor> reply = mInterface.call(
+            QStringLiteral("Inhibit"),
+            QStringLiteral("sleep"),
+            QStringLiteral("LXQt Power Management"),
+            QStringLiteral("Start screen locker before sleep."),
+            QStringLiteral("delay"));
+
+    if (!reply.isValid())
+    {
+        qDebug() << "LockScreenWatcher: " << reply.error();
+        return false;
+    }
+
+    mFileDescriptor = reply.value();
+    return true;
+}
+
+void ConsoleKit2Provider::release()
+{
+    if (mFileDescriptor.isValid())
+    {
+        ::close(mFileDescriptor.fileDescriptor());
+        mFileDescriptor.setFileDescriptor(-1);
+    }
+}

--- a/lxqt-session/src/lockscreenmanager.cpp
+++ b/lxqt-session/src/lockscreenmanager.cpp
@@ -60,12 +60,18 @@ bool LockScreenManager::startup()
 
     if (mProvider)
     {
+        qDebug() << "LockScreenManager:"
+                << mProvider->metaObject()->className()
+                << "will be used";
+
         connect(mProvider,
                 &LockScreenProvider::aboutToSleep,
                 [this] (bool beforeSleep)
         {
             if (beforeSleep)
             {
+                qDebug() << "LockScreenManager: system is about to sleep";
+
                 mScreenSaver.lockScreen();
                 mLoop.exec();
                 mProvider->release();
@@ -81,6 +87,8 @@ bool LockScreenManager::startup()
 
         return mProvider->inhibit();
     }
+    else
+        qDebug() << "LockScreenManager: no valid provider";
 
     return false;
 }

--- a/lxqt-session/src/lockscreenmanager.h
+++ b/lxqt-session/src/lockscreenmanager.h
@@ -1,0 +1,106 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org/
+ *
+ * Copyright: 2016 LXQt team
+ * Authors:
+ *   Paulo Lieuthier <paulolieuthier@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#ifndef LOCKSCREENMANAGER_H
+#define LOCKSCREENMANAGER_H
+
+#include <QObject>
+#include <QEventLoop>
+#include <QDBusInterface>
+#include <QDBusUnixFileDescriptor>
+#include <LXQt/ScreenSaver>
+
+class LockScreenProvider : public QObject
+{
+    Q_OBJECT
+
+public:
+    virtual ~LockScreenProvider() {}
+
+    virtual bool isValid() = 0;
+    virtual bool inhibit() = 0;
+    virtual void release() = 0;
+
+signals:
+    void aboutToSleep(bool beforeSleep);
+    void lockRequested();
+};
+
+class LogindProvider : public LockScreenProvider
+{
+    Q_OBJECT
+
+public:
+    explicit LogindProvider();
+    virtual ~LogindProvider();
+
+    bool isValid() override;
+    bool inhibit() override;
+    void release() override;
+
+private:
+    QDBusInterface mInterface;
+    QDBusUnixFileDescriptor mFileDescriptor;
+};
+
+class ConsoleKit2Provider : public LockScreenProvider
+{
+    Q_OBJECT
+
+public:
+    explicit ConsoleKit2Provider();
+    virtual ~ConsoleKit2Provider();
+
+    bool isValid() override;
+    bool inhibit() override;
+    void release() override;
+
+private:
+    QDBusInterface mInterface;
+    bool mMethodInhibitPresent;
+    QDBusUnixFileDescriptor mFileDescriptor;
+};
+
+class LockScreenManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit LockScreenManager(QObject *parent = nullptr);
+    virtual ~LockScreenManager();
+
+    bool startup();
+
+private:
+    LockScreenProvider *mProvider;
+
+    // screensaver
+    LXQt::ScreenSaver mScreenSaver;
+    QEventLoop mLoop;
+};
+
+#endif

--- a/lxqt-session/src/sessionapplication.h
+++ b/lxqt-session/src/sessionapplication.h
@@ -24,6 +24,7 @@
 #include <LXQt/Settings>
 
 class LXQtModuleManager;
+class LockScreenManager;
 
 class SessionApplication : public LXQt::Application
 {
@@ -47,6 +48,7 @@ private:
     void setLeftHandedMouse(bool mouse_left_handed);
 private:
     LXQtModuleManager* modman;
+    LockScreenManager *lockScreenManager;
     QString configName;
 };
 


### PR DESCRIPTION
This is the result of the work in lxde/lxqt-powermanagement#32. Fixes lxde/lxqt#431 and fixes lxde/lxqt#775.

This supports both logind and ConsoleKit2 and relies on LXQt::ScreenSaver for locking. ConsoleKit2 support has yet to be tested.