### PR TITLE
Adds an WITH_LIBUDEV CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 project(lxqt-session)
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
+option(WITH_LIBUDEV "Build with libudev support" ON)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/cmake/FindUDev.cmake
+++ b/cmake/FindUDev.cmake
@@ -1,0 +1,50 @@
+# - Try to find the UDev library
+# Once done this will define
+#
+#  UDEV_FOUND - system has UDev
+#  UDEV_INCLUDE_DIR - the libudev include directory
+#  UDEV_LIBS - The libudev libraries
+
+# Copyright (c) 2010, Rafael Fernández López, <ereslibre@kde.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the name of the University nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+find_path(UDEV_INCLUDE_DIR libudev.h)
+find_library(UDEV_LIBS udev)
+
+if(UDEV_INCLUDE_DIR AND UDEV_LIBS)
+   include(CheckFunctionExists)
+   include(CMakePushCheckState)
+   cmake_push_check_state()
+   set(CMAKE_REQUIRED_LIBRARIES ${UDEV_LIBS} )
+
+   cmake_pop_check_state()
+
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(UDev DEFAULT_MSG UDEV_INCLUDE_DIR UDEV_LIBS)
+
+mark_as_advanced(UDEV_INCLUDE_DIR UDEV_LIBS)

--- a/lxqt-session/CMakeLists.txt
+++ b/lxqt-session/CMakeLists.txt
@@ -5,13 +5,9 @@ if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if(LIBUDEV_MONITOR)
-    set(LIBUDEV_MONITOR Yes)
-
-    find_package(PkgConfig)
-    pkg_check_modules(LIBUDEV REQUIRED libudev)
-    include_directories(${LIBUDEV_INCLUDE_DIRS})
-
+if (WITH_LIBUDEV)
+    find_package(UDev REQUIRED)
+    include_directories(${LIBUDEV_INCLUDE_DIR})
     add_definitions(-DWITH_LIBUDEV_MONITOR)
 endif()
 
@@ -19,9 +15,6 @@ include_directories(
     ${XCB_INCLUDE_DIRS}
     ${X11_INCLUDE_DIR}
 )
-if(LIBUDEV_MONITOR)
-    include_directories(${LIBUDEV_INCLUDE_DIRS})
-endif()
 
 set(lxqt-session_HDRS "")
 
@@ -35,7 +28,7 @@ set(lxqt-session_SRCS
     src/numlock.cpp
     src/numlock.h
 )
-if(LIBUDEV_MONITOR)
+if (WITH_LIBUDEV)
     list(APPEND lxqt-session_SRCS src/UdevNotifier.cpp)
 endif()
 
@@ -82,8 +75,9 @@ target_link_libraries(lxqt-session
     lxqt
     KF5::WindowSystem
 )
-if(LIBUDEV_MONITOR)
-    target_link_libraries(lxqt-session ${LIBUDEV_LDFLAGS})
+
+if (WITH_LIBUDEV)
+    target_link_libraries(lxqt-session ${UDEV_LIBS})
 endif()
 
 INSTALL(TARGETS


### PR DESCRIPTION
If the WITH_LIBUDEV option is set and the udev library isn't found a fatal
error is generated and the configure step stops executing.
Defaults to OFF.

Closes lxde/lxqt#989.