### PR TITLE
lxqt-session: Use the base name to compare Wm's names

### DIFF
--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -192,8 +192,8 @@ void LXQtModuleManager::startWm(LXQt::Settings *settings)
         settings->setValue("window_manager", mWindowManager);
         settings->sync();
     }
-    
-    if(mWindowManager == "openbox")
+
+    if (QFileInfo(mWindowManager).baseName() == "openbox")
     {
         // Default settings of openbox are copied by lxqt-common/startlxqt.in
         QString openboxSettingsPath = XdgDirs::configHome() + "/openbox/lxqt-rc.xml";


### PR DESCRIPTION
mWindowManager can be the full path in some situations.
Closes lxde/lxqt#1073