### PR TITLE
lxqt-session: Use QLoggingCategory for logging/debug

### DIFF
--- a/lxqt-session/CMakeLists.txt
+++ b/lxqt-session/CMakeLists.txt
@@ -34,6 +34,7 @@ set(lxqt-session_SRCS
     src/sessiondbusadaptor.h
     src/numlock.cpp
     src/numlock.h
+    src/log.cpp
 )
 if(LIBUDEV_MONITOR)
     list(APPEND lxqt-session_SRCS src/UdevNotifier.cpp)

--- a/lxqt-session/src/UdevNotifier.cpp
+++ b/lxqt-session/src/UdevNotifier.cpp
@@ -26,8 +26,8 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include "UdevNotifier.h"
+#include "log.h"
 #include <libudev.h>
-#include <QDebug>
 #include <QSocketNotifier>
 
 
@@ -48,18 +48,18 @@ UdevNotifier::UdevNotifier(QString const & subsystem, QObject * parent/* = nullp
     d->monitor = udev_monitor_new_from_netlink(d->udev, "udev");
     if (nullptr == d->monitor)
     {
-        qWarning() << QStringLiteral("UdevNotifier: unable to initialize udev_monitor, monitoring will be disabled");
+        qCWarning(SESSION) << QStringLiteral("UdevNotifier: unable to initialize udev_monitor, monitoring will be disabled");
         return;
     }
 
     int ret = udev_monitor_filter_add_match_subsystem_devtype(d->monitor, subsystem.toUtf8().constData(), nullptr);
     if (0 != ret)
-        qWarning() << QStringLiteral("UdevNotifier: unable to add match subsystem, monitor will receive all devices");
+        qCWarning(SESSION) << QStringLiteral("UdevNotifier: unable to add match subsystem, monitor will receive all devices");
 
     ret = udev_monitor_enable_receiving(d->monitor);
     if (0 != ret)
     {
-        qWarning() << QStringLiteral("UdevNotifier: unable to enable receiving(%1), monitoring will be disabled").arg(ret);
+        qCWarning(SESSION) << QStringLiteral("UdevNotifier: unable to enable receiving(%1), monitoring will be disabled").arg(ret);
         return;
     }
 

--- a/lxqt-session/src/log.cpp
+++ b/lxqt-session/src/log.cpp
@@ -1,0 +1,36 @@
+
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org
+ *
+ * Copyright: 2016 LXQt team
+ * Authors:
+ *  Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "log.h"
+#include <QtGlobal>
+
+#if defined(NDEBUG)
+Q_LOGGING_CATEGORY(SESSION, "lxqt-session", QtInfoMsg)
+#else
+Q_LOGGING_CATEGORY(SESSION, "lxqt-session")
+#endif

--- a/lxqt-session/src/log.h
+++ b/lxqt-session/src/log.h
@@ -1,0 +1,35 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org
+ *
+ * Copyright: 2016 LXQt team
+ * Authors:
+ *  Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#if !defined(log_h)
+#define log_h
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(SESSION)
+
+#endif //log_h

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -26,7 +26,7 @@
 #include <csignal>
 #include <LXQt/Settings>
 #include <QProcess>
-#include <QDebug>
+#include "log.h"
 
 #include <QX11Info>
 // XKB, this should be disabled in Wayland?
@@ -76,7 +76,7 @@ SessionApplication::~SessionApplication()
 bool SessionApplication::startup()
 {
     LXQt::Settings settings(configName);
-    qDebug() << __FILE__ << ":" << __LINE__ << "Session" << configName << "about to launch (default 'session')";
+    qCDebug(SESSION) << __FILE__ << ":" << __LINE__ << "Session" << configName << "about to launch (default 'session')";
 
     loadEnvironmentSettings(settings);
     // loadFontSettings(settings);
@@ -97,7 +97,7 @@ bool SessionApplication::startup()
             });
     connect(dev_notifier, &UdevNotifier::deviceAdded, [this, dev_timer] (QString device)
             {
-                qWarning() << QStringLiteral("Session '%1', new input device '%2', keyboard setting will be (optionaly) reloaded...").arg(configName).arg(device);
+                qCInfo(SESSION) << QStringLiteral("Session '%1', new input device '%2', keyboard setting will be (optionaly) reloaded...").arg(configName).arg(device);
                 dev_timer->start();
             });
 #endif
@@ -110,7 +110,7 @@ bool SessionApplication::startup()
 
 void SessionApplication::mergeXrdb(const char* content, int len)
 {
-    qDebug() << "xrdb:" << content;
+    qCDebug(SESSION) << "xrdb:" << content;
     QProcess xrdb;
     xrdb.start("xrdb -merge -");
     xrdb.write(content, len);
@@ -160,7 +160,7 @@ void SessionApplication::setxkbmap(QString layout, QString variant, QString mode
 
 void SessionApplication::loadKeyboardSettings(LXQt::Settings& settings)
 {
-  qDebug() << settings.fileName();
+  qCDebug(SESSION) << settings.fileName();
     settings.beginGroup("Keyboard");
     XKeyboardControl values;
     /* Keyboard settings */


### PR DESCRIPTION
More universal logging. With this we can enable (debug) log messages
also w/o recompilation (by e.g. QT_LOGGING_RULES env var).

ref. lxde/lxqt#1053