### PR TITLE
lxqt-leave: Handles fallback icons the proper way

### DIFF
--- a/lxqt-leave/leavedialog.cpp
+++ b/lxqt-leave/leavedialog.cpp
@@ -36,6 +36,13 @@ LeaveDialog::LeaveDialog(QWidget* parent)
 {
     ui->setupUi(this);
 
+    ui->lockscreenButton->setIcon(QIcon::fromTheme(QLatin1String("system-lock-screen")));
+    ui->logoutButton->setIcon(QIcon::fromTheme(QLatin1String("system-log-out")));
+    ui->shutdownButton->setIcon(QIcon::fromTheme(QLatin1String("system-shutdown")));
+    ui->rebootButton->setIcon(QIcon::fromTheme(QLatin1String("system-reboot")));
+    ui->suspendButton->setIcon(QIcon::fromTheme(QLatin1String("system-suspend")));
+    ui->hibernateButton->setIcon(QIcon::fromTheme(QLatin1String("system-suspend-hibernate")));
+
     /* This is a special dialog. We want to make it hard to ignore.
        We make it:
            * Undraggable

--- a/lxqt-leave/leavedialog.ui
+++ b/lxqt-leave/leavedialog.ui
@@ -91,10 +91,6 @@
           <property name="text">
            <string>Logout</string>
           </property>
-          <property name="icon">
-           <iconset theme="system-log-out">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
           <property name="iconSize">
            <size>
             <width>64</width>
@@ -110,10 +106,6 @@
          <widget class="QToolButton" name="lockscreenButton">
           <property name="text">
            <string>Lock screen</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-lock-screen">
-            <normaloff>.</normaloff>.</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -138,10 +130,6 @@
           <property name="text">
            <string>Suspend</string>
           </property>
-          <property name="icon">
-           <iconset theme="system-suspend">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
           <property name="iconSize">
            <size>
             <width>64</width>
@@ -157,10 +145,6 @@
          <widget class="QToolButton" name="hibernateButton">
           <property name="text">
            <string>Hibernate</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-suspend-hibernate">
-            <normaloff>.</normaloff>.</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -185,10 +169,6 @@
           <property name="text">
            <string>Shutdown</string>
           </property>
-          <property name="icon">
-           <iconset theme="system-shutdown">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
           <property name="iconSize">
            <size>
             <width>64</width>
@@ -204,10 +184,6 @@
          <widget class="QToolButton" name="rebootButton">
           <property name="text">
            <string>Reboot</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-reboot">
-            <normaloff>.</normaloff>.</iconset>
           </property>
           <property name="iconSize">
            <size>


### PR DESCRIPTION
We were setting the icons in the ui file. The generated code uses
QIcon::hasThemeIcon() to check the icon existence. But
QIcon::hasThemeIcon() doesn't take in account the fallbacks. The fallback
icons are never used and we end up with no icon.

Simply using QIcon::fromTheme() in the source code, fixes the issue.