### PR TITLE
lxqt-leave: Redesign dialog for good key navigation

### DIFF
--- a/lxqt-leave/leavedialog.cpp
+++ b/lxqt-leave/leavedialog.cpp
@@ -33,7 +33,7 @@
 class ItemDelegate : public QItemDelegate
 {
 public:
-    static constexpr QMargins MARGINS{20, 10, 20, 10};
+    static constexpr QMargins MARGINS{10, 10, 10, 10};
 public:
     using QItemDelegate::QItemDelegate;
     virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override
@@ -44,13 +44,44 @@ public:
         size += {MARGINS.left() + MARGINS.right(), MARGINS.top() + MARGINS.bottom()}; // add some margins
         return size;
     }
+
     virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
     {
         QStyleOptionViewItem opt = option;
         opt.decorationPosition = QStyleOptionViewItem::Top;
         opt.displayAlignment = Qt::AlignHCenter | Qt::AlignTop;
-        opt.rect -= MARGINS;
         return QItemDelegate::paint(painter, opt, index);
+    }
+
+protected:
+    // Note: We want to paint the focus rectangle around the whole (text+icon)
+    //  (default in QItemDelegate is to draw the focus only in text rectangle)
+    virtual void drawFocus(QPainter *painter
+            , const QStyleOptionViewItem &option
+            , const QRect &/*rect*/) const override
+    {
+        // don't override the rectangle to the text-only
+        return QItemDelegate::drawFocus(painter, option, option.rect);
+    }
+
+    virtual void drawDisplay(QPainter *painter
+            , const QStyleOptionViewItem &option
+            , const QRect &rect
+            , const QString &text) const override
+    {
+        // shrink (and move to bottom) the text rectangle
+        QRect r = rect.adjusted(0, MARGINS.top(), 0, 0);
+        return QItemDelegate::drawDisplay(painter, option, r, text);
+    }
+
+    virtual void drawDecoration(QPainter *painter
+            , const QStyleOptionViewItem &option
+            , const QRect &rect
+            , const QPixmap &pixmap) const override
+    {
+        // move to bottom the pixmap rectangle
+        QRect r = rect.translated(0, MARGINS.top());
+        return QItemDelegate::drawDecoration(painter, option, r, pixmap);
     }
 };
 constexpr QMargins ItemDelegate::MARGINS;
@@ -84,38 +115,56 @@ LeaveDialog::LeaveDialog(QWidget* parent)
     // populate the items
     ui->tableWidget->setColumnCount(3);
     ui->tableWidget->setRowCount(2);
-    QTableWidgetItem * item = new QTableWidgetItem{QIcon::fromTheme("system-log-out"), tr("Logout")};
+    QTableWidgetItem * item = new QTableWidgetItem{QIcon::fromTheme(QStringLiteral("system-log-out")), tr("Logout")};
     item->setData(Qt::UserRole, LXQt::Power::PowerLogout);
     if (!mPower->canAction(LXQt::Power::PowerLogout))
         item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
     ui->tableWidget->setItem(0, 0, item);
-    item = new QTableWidgetItem{QIcon::fromTheme("system-shutdown"), tr("Shutdown")};
+    item = new QTableWidgetItem{QIcon::fromTheme(QStringLiteral("system-shutdown")), tr("Shutdown")};
     item->setData(Qt::UserRole, LXQt::Power::PowerShutdown);
     if (!mPower->canAction(LXQt::Power::PowerShutdown))
         item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
     ui->tableWidget->setItem(0, 1, item);
-    item = new QTableWidgetItem{QIcon::fromTheme("system-suspend"), tr("Suspend")};
+    item = new QTableWidgetItem{QIcon::fromTheme(QStringLiteral("system-suspend")), tr("Suspend")};
     item->setData(Qt::UserRole, LXQt::Power::PowerSuspend);
     if (!mPower->canAction(LXQt::Power::PowerSuspend))
         item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
     ui->tableWidget->setItem(0, 2, item);
-    item = new QTableWidgetItem{QIcon::fromTheme("system-lock-screen"), tr("Lock screen")};
+    item = new QTableWidgetItem{QIcon::fromTheme(QStringLiteral("system-lock-screen")), tr("Lock screen")};
     item->setData(Qt::UserRole, -1);
     ui->tableWidget->setItem(1, 0, item);
-    item = new QTableWidgetItem{QIcon::fromTheme("system-reboot"), tr("Reboot")};
+    item = new QTableWidgetItem{QIcon::fromTheme(QStringLiteral("system-reboot")), tr("Reboot")};
     item->setData(Qt::UserRole, LXQt::Power::PowerReboot);
     if (!mPower->canAction(LXQt::Power::PowerReboot))
         item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
     ui->tableWidget->setItem(1, 1, item);
-    item = new QTableWidgetItem{QIcon::fromTheme("system-suspend-hibernate"), tr("Hibernate")};
+    item = new QTableWidgetItem{QIcon::fromTheme(QStringLiteral("system-suspend-hibernate")), tr("Hibernate")};
     item->setData(Qt::UserRole, LXQt::Power::PowerHibernate);
     if (!mPower->canAction(LXQt::Power::PowerHibernate))
         item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
     ui->tableWidget->setItem(1, 2, item);
 
-    connect(ui->tableWidget, &QTableWidget::itemActivated, this, [this] (QTableWidgetItem *item) {
+    // set unified size for all cells
+    int height = 0;
+    for (int row = 0; row < ui->tableWidget->rowCount(); ++row)
+        height = qMax(height, ui->tableWidget->rowHeight(row));
+    int width = 0;
+    for (int col = 0; col < ui->tableWidget->columnCount(); ++col)
+        width = qMax(width, ui->tableWidget->columnWidth(col));
+    for (int row = 0; row < ui->tableWidget->rowCount(); ++row)
+    {
+        ui->tableWidget->verticalHeader()->setSectionResizeMode(row, QHeaderView::Fixed);
+        ui->tableWidget->setRowHeight(row, height);
+    }
+    for (int col = 0; col < ui->tableWidget->columnCount(); ++col)
+    {
+        ui->tableWidget->horizontalHeader()->setSectionResizeMode(col, QHeaderView::Fixed);
+        ui->tableWidget->setColumnWidth(col, width);
+    }
+
+    connect(ui->tableWidget, &QAbstractItemView::activated, this, [this] (const QModelIndex & index) {
         bool ok = false;
-        const int action = item->data(Qt::UserRole).toInt(&ok);
+        const int action = index.data(Qt::UserRole).toInt(&ok);
         if (!ok)
         {
             qWarning("Invalid internal logic, no UserRole set!?");

--- a/lxqt-leave/leavedialog.h
+++ b/lxqt-leave/leavedialog.h
@@ -50,7 +50,6 @@ public:
 
 protected:
     virtual void resizeEvent(QResizeEvent* event) override;
-    virtual void keyPressEvent(QKeyEvent* event) override;
 
 private:
     Ui::LeaveDialog *ui;

--- a/lxqt-leave/leavedialog.ui
+++ b/lxqt-leave/leavedialog.ui
@@ -126,9 +126,6 @@ QAbstractItemView { activate-on-singleclick: 1; }</string>
      <property name="showGrid">
       <bool>false</bool>
      </property>
-     <property name="gridStyle">
-      <enum>Qt::NoPen</enum>
-     </property>
      <property name="wordWrap">
       <bool>false</bool>
      </property>
@@ -138,13 +135,7 @@ QAbstractItemView { activate-on-singleclick: 1; }</string>
      <attribute name="horizontalHeaderVisible">
       <bool>false</bool>
      </attribute>
-     <attribute name="horizontalHeaderHighlightSections">
-      <bool>false</bool>
-     </attribute>
      <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="verticalHeaderHighlightSections">
       <bool>false</bool>
      </attribute>
     </widget>

--- a/lxqt-leave/leavedialog.ui
+++ b/lxqt-leave/leavedialog.ui
@@ -20,7 +20,16 @@
    <string>Leave</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="2" column="0">
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <property name="horizontalSpacing">
+    <number>0</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>18</number>
+   </property>
+   <item row="3" column="0">
     <widget class="QWidget" name="widget_2" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
@@ -70,192 +79,81 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="buttonsWidget" native="true">
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="horizontalSpacing">
-       <number>12</number>
-      </property>
-      <item row="0" column="0">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="logoutButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="contextMenuPolicy">
-           <enum>Qt::NoContextMenu</enum>
-          </property>
-          <property name="text">
-           <string>Logout</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-log-out">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="lockscreenButton">
-          <property name="text">
-           <string>Lock screen</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-lock-screen">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="4">
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="suspendButton">
-          <property name="text">
-           <string>Suspend</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-suspend">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="hibernateButton">
-          <property name="text">
-           <string>Hibernate</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-suspend-hibernate">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="2">
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="shutdownButton">
-          <property name="text">
-           <string>Shutdown</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-shutdown">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="rebootButton">
-          <property name="text">
-           <string>Reboot</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-reboot">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="1">
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="Line" name="line_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-     </layout>
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="contextMenuPolicy">
+      <enum>Qt::NoContextMenu</enum>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">#tableWidget { background-color: palette(window); }
+QAbstractItemView { activate-on-singleclick: 1; }</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+     </property>
+     <property name="autoScroll">
+      <bool>false</bool>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>64</width>
+       <height>64</height>
+      </size>
+     </property>
+     <property name="textElideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="showGrid">
+      <bool>false</bool>
+     </property>
+     <property name="gridStyle">
+      <enum>Qt::NoPen</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+     <property name="cornerButtonEnabled">
+      <bool>false</bool>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderHighlightSections">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderHighlightSections">
+      <bool>false</bool>
+     </attribute>
     </widget>
    </item>
   </layout>
   <zorder>label</zorder>
-  <zorder>buttonsWidget</zorder>
+  <zorder>tableWidget</zorder>
   <zorder>widget_2</zorder>
  </widget>
- <tabstops>
-  <tabstop>cancelButton</tabstop>
-  <tabstop>logoutButton</tabstop>
-  <tabstop>shutdownButton</tabstop>
-  <tabstop>suspendButton</tabstop>
-  <tabstop>lockscreenButton</tabstop>
-  <tabstop>rebootButton</tabstop>
-  <tabstop>hibernateButton</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
By use of "standalone" buttons there was no easy way to navigate
through the buttons with up/down/left/right keys. All homemade key
filtering techniques could be considered as "fragile" (mixing
definition in .ui with some logic estimations in .cpp).

Using a QTableView/Widget seems to be more robust way -> let the Qt do
the navigation job.

closes lxde/lxqt#1183