### PR TITLE
lxqt-leave: Redesign dialog for good key navigation

### DIFF
--- a/lxqt-leave/CMakeLists.txt
+++ b/lxqt-leave/CMakeLists.txt
@@ -3,10 +3,12 @@ project(lxqt-leave)
 set(CPP_FILES
     main.cpp
     leavedialog.cpp
+    listwidget.cpp
 )
 
 set(H_FILES
     leavedialog.h
+    listwidget.h
 )
 
 set(UI_FILES

--- a/lxqt-leave/leavedialog.cpp
+++ b/lxqt-leave/leavedialog.cpp
@@ -124,7 +124,7 @@ LeaveDialog::~LeaveDialog()
     delete ui;
 }
 
-void LeaveDialog::resizeEvent(QResizeEvent* event)
+void LeaveDialog::resizeEvent(QResizeEvent* /*event*/)
 {
     QRect screen = QApplication::desktop()->screenGeometry();
     move((screen.width()  - this->width()) / 2,

--- a/lxqt-leave/leavedialog.cpp
+++ b/lxqt-leave/leavedialog.cpp
@@ -26,7 +26,7 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include "leavedialog.h"
-#include <QKeyEvent>
+#include <QListWidgetItem>
 
 LeaveDialog::LeaveDialog(QWidget* parent)
     : QDialog(parent, Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint),
@@ -47,47 +47,76 @@ LeaveDialog::LeaveDialog(QWidget* parent)
     setWindowFlags((Qt::CustomizeWindowHint | Qt::FramelessWindowHint |
                     Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint));
 
-    ui->logoutButton->setEnabled(mPower->canAction(LXQt::Power::PowerLogout));
-    ui->rebootButton->setEnabled(mPower->canAction(LXQt::Power::PowerReboot));
-    ui->shutdownButton->setEnabled(mPower->canAction(LXQt::Power::PowerShutdown));
-    ui->suspendButton->setEnabled(mPower->canAction(LXQt::Power::PowerSuspend));
-    ui->hibernateButton->setEnabled(mPower->canAction(LXQt::Power::PowerHibernate));
+    // populate the items
+    QListWidgetItem * item = new QListWidgetItem{QIcon::fromTheme(QStringLiteral("system-log-out")), tr("Logout")};
+    item->setData(Qt::UserRole, LXQt::Power::PowerLogout);
+    if (!mPower->canAction(LXQt::Power::PowerLogout))
+        item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+    ui->listWidget->addItem(item);
+    item = new QListWidgetItem{QIcon::fromTheme(QStringLiteral("system-shutdown")), tr("Shutdown")};
+    item->setData(Qt::UserRole, LXQt::Power::PowerShutdown);
+    if (!mPower->canAction(LXQt::Power::PowerShutdown))
+        item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+    ui->listWidget->addItem(item);
+    item = new QListWidgetItem{QIcon::fromTheme(QStringLiteral("system-suspend")), tr("Suspend")};
+    item->setData(Qt::UserRole, LXQt::Power::PowerSuspend);
+    if (!mPower->canAction(LXQt::Power::PowerSuspend))
+        item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+    ui->listWidget->addItem(item);
+    item = new QListWidgetItem{QIcon::fromTheme(QStringLiteral("system-lock-screen")), tr("Lock screen")};
+    item->setData(Qt::UserRole, -1);
+    ui->listWidget->addItem(item);
+    item = new QListWidgetItem{QIcon::fromTheme(QStringLiteral("system-reboot")), tr("Reboot")};
+    item->setData(Qt::UserRole, LXQt::Power::PowerReboot);
+    if (!mPower->canAction(LXQt::Power::PowerReboot))
+        item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+    ui->listWidget->addItem(item);
+    item = new QListWidgetItem{QIcon::fromTheme(QStringLiteral("system-suspend-hibernate")), tr("Hibernate")};
+    item->setData(Qt::UserRole, LXQt::Power::PowerHibernate);
+    if (!mPower->canAction(LXQt::Power::PowerHibernate))
+        item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+    ui->listWidget->addItem(item);
 
-    /*
-     * Make all the buttons have equal widths
-     */
-    QVector<QToolButton*> buttons(6);
-    buttons[0] = ui->logoutButton;
-    buttons[1] = ui->lockscreenButton;
-    buttons[2] = ui->suspendButton;
-    buttons[3] = ui->hibernateButton;
-    buttons[4] = ui->rebootButton;
-    buttons[5] = ui->shutdownButton;
+    ui->listWidget->setRows(2);
+    ui->listWidget->setColumns(3);
 
-    int maxWidth = 0;
-    const int N = buttons.size();
-    for (int i = 0; i < N; ++i) {
-        // Make sure that the button size is adjusted to the text width
-        buttons.at(i)->adjustSize();
-        maxWidth = qMax(maxWidth, buttons.at(i)->width());
-    }
-    for (int i = 0; i < N; ++i)
-        buttons.at(i)->setMinimumWidth(maxWidth);
-
-    connect(ui->logoutButton,       &QAbstractButton::clicked, [&] { close(); mPowerManager->logout();    });
-    connect(ui->rebootButton,       &QAbstractButton::clicked, [&] { close(); mPowerManager->reboot();    });
-    connect(ui->shutdownButton,     &QAbstractButton::clicked, [&] { close(); mPowerManager->shutdown();  });
-    connect(ui->suspendButton,      &QAbstractButton::clicked, [&] { close(); mPowerManager->suspend();   });
-    connect(ui->hibernateButton,    &QAbstractButton::clicked, [&] { close(); mPowerManager->hibernate(); });
-    connect(ui->cancelButton,       &QAbstractButton::clicked, [&] { close();                             });
-    connect(ui->lockscreenButton,   &QAbstractButton::clicked, [&] {
+    connect(ui->listWidget, &QAbstractItemView::activated, this, [this] (const QModelIndex & index) {
+        bool ok = false;
+        const int action = index.data(Qt::UserRole).toInt(&ok);
+        if (!ok)
+        {
+            qWarning("Invalid internal logic, no UserRole set!?");
+            return;
+        }
         close();
-        QEventLoop loop;
-        connect(mScreensaver, &LXQt::ScreenSaver::done, &loop, &QEventLoop::quit);
-        mScreensaver->lockScreen();
-        loop.exec();
+        switch (action)
+        {
+        case LXQt::Power::PowerLogout:
+                mPowerManager->logout();
+                break;
+            case LXQt::Power::PowerShutdown:
+                mPowerManager->shutdown();
+                break;
+            case LXQt::Power::PowerSuspend:
+                mPowerManager->suspend();
+                break;
+            case -1:
+                {
+                    QEventLoop loop;
+                    connect(mScreensaver, &LXQt::ScreenSaver::done, &loop, &QEventLoop::quit);
+                    mScreensaver->lockScreen();
+                    loop.exec();
+                }
+                break;
+            case LXQt::Power::PowerReboot:
+                mPowerManager->reboot();
+                break;
+            case LXQt::Power::PowerHibernate:
+                mPowerManager->hibernate();
+                break;
+        }
     });
-
+    connect(ui->cancelButton, &QAbstractButton::clicked, this, [this] { close(); });
 }
 
 LeaveDialog::~LeaveDialog()
@@ -101,17 +130,4 @@ void LeaveDialog::resizeEvent(QResizeEvent* event)
     move((screen.width()  - this->width()) / 2,
          (screen.height() - this->height()) / 2);
 
-}
-
-void LeaveDialog::keyPressEvent(QKeyEvent* event)
-{
-    if (Qt::Key_Enter == event->key() || Qt::Key_Return == event->key())
-    {
-        if (QToolButton * button = qobject_cast<QToolButton *>(QApplication::focusWidget()))
-        {
-            button->click();
-            return;
-        }
-    }
-    QDialog::keyPressEvent(event);
 }

--- a/lxqt-leave/leavedialog.ui
+++ b/lxqt-leave/leavedialog.ui
@@ -105,6 +105,9 @@ QAbstractItemView { activate-on-singleclick: 1; }</string>
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
      </property>
+     <property name="tabKeyNavigation">
+      <bool>true</bool>
+     </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>
      </property>

--- a/lxqt-leave/leavedialog.ui
+++ b/lxqt-leave/leavedialog.ui
@@ -20,7 +20,16 @@
    <string>Leave</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="2" column="0">
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <property name="horizontalSpacing">
+    <number>0</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>18</number>
+   </property>
+   <item row="3" column="0">
     <widget class="QWidget" name="widget_2" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
@@ -70,192 +79,70 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QWidget" name="buttonsWidget" native="true">
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="horizontalSpacing">
-       <number>12</number>
-      </property>
-      <item row="0" column="0">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="logoutButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="contextMenuPolicy">
-           <enum>Qt::NoContextMenu</enum>
-          </property>
-          <property name="text">
-           <string>Logout</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-log-out">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="lockscreenButton">
-          <property name="text">
-           <string>Lock screen</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-lock-screen">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="4">
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="suspendButton">
-          <property name="text">
-           <string>Suspend</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-suspend">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="hibernateButton">
-          <property name="text">
-           <string>Hibernate</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-suspend-hibernate">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="2">
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="shutdownButton">
-          <property name="text">
-           <string>Shutdown</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-shutdown">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignHCenter">
-         <widget class="QToolButton" name="rebootButton">
-          <property name="text">
-           <string>Reboot</string>
-          </property>
-          <property name="icon">
-           <iconset theme="system-reboot">
-            <normaloff>.</normaloff>.</iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>64</width>
-            <height>64</height>
-           </size>
-          </property>
-          <property name="toolButtonStyle">
-           <enum>Qt::ToolButtonTextUnderIcon</enum>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="1">
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="Line" name="line_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
-     </layout>
+    <widget class="ListWidget" name="listWidget">
+     <property name="contextMenuPolicy">
+      <enum>Qt::NoContextMenu</enum>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">#listWidget { background-color: palette(window); }
+QAbstractItemView { activate-on-singleclick: 1; }</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="autoScroll">
+      <bool>false</bool>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>64</width>
+       <height>64</height>
+      </size>
+     </property>
+     <property name="textElideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="flow">
+      <enum>QListView::LeftToRight</enum>
+     </property>
+     <property name="isWrapping" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="spacing">
+      <number>7</number>
+     </property>
+     <property name="uniformItemSizes">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
   </layout>
   <zorder>label</zorder>
-  <zorder>buttonsWidget</zorder>
+  <zorder>listWidget</zorder>
   <zorder>widget_2</zorder>
  </widget>
- <tabstops>
-  <tabstop>cancelButton</tabstop>
-  <tabstop>logoutButton</tabstop>
-  <tabstop>shutdownButton</tabstop>
-  <tabstop>suspendButton</tabstop>
-  <tabstop>lockscreenButton</tabstop>
-  <tabstop>rebootButton</tabstop>
-  <tabstop>hibernateButton</tabstop>
- </tabstops>
+ <customwidgets>
+  <customwidget>
+   <class>ListWidget</class>
+   <extends>QListWidget</extends>
+   <header>listwidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/lxqt-leave/listwidget.cpp
+++ b/lxqt-leave/listwidget.cpp
@@ -35,7 +35,7 @@
  * - returns unified sizeHint() -> maximum of all items in (list) model
  * - cahes the sizeHint() to not iterate over all items and checking their size
  * - overrides decoration position to Qt::Top
- * - gives the items margins (increasing sizeHint()) and mimics Button visual
+ * - gives the items margins (increasing sizeHint()) ~~and mimics Button visual~~
  * - overrides painting the focus around the whole item (with the decoration)
  *
  * \note It is a single purpose delegate and expects, that the model
@@ -66,6 +66,7 @@ public:
 
     virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
     {
+        /*
         // mimic the button visual
         QStyleOption button_option;
         button_option.initFrom(option.widget);
@@ -74,7 +75,7 @@ public:
             button_option.state &= ~QStyle::State_HasFocus;
         QStyle * style = option.widget->style() ? option.widget->style() : QApplication::style();
         style->drawPrimitive(QStyle::PE_PanelButtonTool, &button_option, painter, option.widget);
-
+        */
         QStyleOptionViewItem opt = option;
         opt.decorationPosition = QStyleOptionViewItem::Top;
         opt.displayAlignment = Qt::AlignHCenter | Qt::AlignTop;
@@ -89,8 +90,7 @@ protected:
             , const QRect &/*rect*/) const override
     {
         // don't override the rectangle to the text-only
-        QRect rect = option.rect.adjusted(3, 3, -3, -3);
-        return QItemDelegate::drawFocus(painter, option, rect);
+        return QItemDelegate::drawFocus(painter, option, option.rect);
     }
 
     virtual void drawDisplay(QPainter *painter
@@ -147,7 +147,7 @@ QSize ListWidget::viewportSizeHint() const
     return size;
 }
 
-QModelIndex ListWidget::moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers)
+QModelIndex ListWidget::moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers/* modifiers*/)
 {
     QModelIndex current_index = currentIndex();
     int count = model()->rowCount(rootIndex());
@@ -201,7 +201,7 @@ void ListWidget::keyPressEvent(QKeyEvent * event)
 {
     if (event->key() == Qt::Key_Space)
     {
-        // mimic the "select" to fire activated
+        // mimic the "enter" to fire activated
         QKeyEvent k{event->type(), Qt::Key_Enter, event->modifiers(), event->text(), event->isAutoRepeat(), static_cast<ushort>(event->count())};
         QListWidget::keyPressEvent(&k);
         event->setAccepted(k.isAccepted());

--- a/lxqt-leave/listwidget.cpp
+++ b/lxqt-leave/listwidget.cpp
@@ -1,0 +1,149 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * http://lxqt.org/
+ *
+ * Copyright: 2017 LXQt team
+ * Authors:
+ *   Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "listwidget.h"
+#include <QItemDelegate>
+#include <QDebug>
+#include <QApplication>
+
+
+/*!
+ * This private delegate does:
+ * - returns unified sizeHint() -> maximum of all items in (list) model
+ * - cahes the sizeHint() to not iterate over all items and checking their size
+ * - overrides decoration position to Qt::Top
+ * - gives the items margins (increasing sizeHint()) and mimics Button visual
+ * - overrides painting the focus around the whole item (with the decoration)
+ *
+ * \note It is a single purpose delegate and expects, that the model
+ * never changes (cached sizeHint() is never invalidated).
+ */
+class ItemDelegate : public QItemDelegate
+{
+public:
+    static constexpr QMargins MARGINS{5, 5, 5, 5};
+public:
+    using QItemDelegate::QItemDelegate;
+    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override
+    {
+        if (mItemSize.isValid())
+            return mItemSize;
+
+        // compute maximum item size
+        QStyleOptionViewItem opt = option;
+        opt.decorationPosition = QStyleOptionViewItem::Top;
+        QAbstractListModel const * model = qobject_cast<QAbstractListModel const *>(index.model());
+        for (QModelIndex i = model->index(0); i.isValid(); i = model->index(i.row() + 1))
+        {
+            mItemSize = mItemSize.expandedTo(QItemDelegate::sizeHint(opt, i));
+        }
+        mItemSize += {MARGINS.left() + MARGINS.right(), MARGINS.top() + MARGINS.bottom()}; // add some margins
+        return mItemSize;
+    }
+
+    virtual void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
+    {
+        // mimic the button visual
+        QStyleOption button_option;
+        button_option.initFrom(option.widget);
+        button_option.rect = option.rect;
+        if (!(option.state & QStyle::State_HasFocus))
+            button_option.state &= ~QStyle::State_HasFocus;
+        QStyle * style = option.widget->style() ? option.widget->style() : QApplication::style();
+        style->drawPrimitive(QStyle::PE_PanelButtonTool, &button_option, painter, option.widget);
+
+        QStyleOptionViewItem opt = option;
+        opt.decorationPosition = QStyleOptionViewItem::Top;
+        opt.displayAlignment = Qt::AlignHCenter | Qt::AlignTop;
+        return QItemDelegate::paint(painter, opt, index);
+    }
+
+protected:
+    // Note: We want to paint the focus rectangle around the whole (text+icon)
+    //  (default in QItemDelegate is to draw the focus only in text rectangle)
+    virtual void drawFocus(QPainter *painter
+            , const QStyleOptionViewItem &option
+            , const QRect &/*rect*/) const override
+    {
+        // don't override the rectangle to the text-only
+        QRect rect = option.rect.adjusted(3, 3, -3, -3);
+        return QItemDelegate::drawFocus(painter, option, rect);
+    }
+
+    virtual void drawDisplay(QPainter *painter
+            , const QStyleOptionViewItem &option
+            , const QRect &rect
+            , const QString &text) const override
+    {
+        // shrink (and move to bottom) the text rectangle
+        QRect r = rect.adjusted(0, MARGINS.top(), 0, 0);
+        return QItemDelegate::drawDisplay(painter, option, r, text);
+    }
+
+    virtual void drawDecoration(QPainter *painter
+            , const QStyleOptionViewItem &option
+            , const QRect &rect
+            , const QPixmap &pixmap) const override
+    {
+        // move to bottom the pixmap rectangle
+        QRect r = rect.translated(0, MARGINS.top());
+        return QItemDelegate::drawDecoration(painter, option, r, pixmap);
+    }
+private:
+    mutable QSize mItemSize; //!< the cached (unified/max) item size
+};
+constexpr QMargins ItemDelegate::MARGINS;
+
+ListWidget::ListWidget(QWidget * parent/* = nullptr*/)
+    : QListWidget{parent}
+    , mRows(3)
+    , mColumns(3)
+{
+    ItemDelegate * delegate = new ItemDelegate{this};
+    {
+        QScopedPointer<QAbstractItemDelegate> old_del{itemDelegate()};
+        setItemDelegate(delegate);
+    }
+}
+
+QSize ListWidget::viewportSizeHint() const
+{
+    QSize size = sizeHintForIndex(model()->index(0, 0));
+    size.rwidth() = size.width() * mColumns + spacing() * mColumns * 2 + 1;
+    size.rheight() = size.height() * mRows + spacing() * mRows * 2 + 1;
+    return size;
+}
+
+void ListWidget::setRows(int rows)
+{
+    mRows = rows;
+}
+
+void ListWidget::setColumns(int columns)
+{
+    mColumns = columns;
+}

--- a/lxqt-leave/listwidget.h
+++ b/lxqt-leave/listwidget.h
@@ -42,6 +42,9 @@ public:
 
 protected:
     virtual QSize viewportSizeHint() const override;
+    virtual QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
+    virtual void keyPressEvent(QKeyEvent * event) override;
+    virtual void focusInEvent(QFocusEvent * event) override;
 
 private:
     int mRows;

--- a/lxqt-leave/listwidget.h
+++ b/lxqt-leave/listwidget.h
@@ -2,11 +2,11 @@
  * (c)LGPL2+
  *
  * LXQt - a lightweight, Qt based, desktop toolset
- * http://razor-qt.org, http://lxde.org/
+ * http://lxqt.org/
  *
- * Copyright: 2010-2015 LXQt team
+ * Copyright: 2017 LXQt team
  * Authors:
- *   Paulo Lieuthier <paulolieuthier@gmail.com>
+ *   Palo Kisa <palo.kisa@gmail.com>
  *
  * This program or library is free software; you can redistribute it
  * and/or modify it under the terms of the GNU Lesser General Public
@@ -25,41 +25,25 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#ifndef LEAVEDIALOG_H
-#define LEAVEDIALOG_H
+#include <QListWidget>
 
-#include "ui_leavedialog.h"
-
-#include <QDialog>
-#include <QDesktopWidget>
-#include <LXQt/Power>
-#include <LXQt/PowerManager>
-#include <LXQt/ScreenSaver>
-
-namespace Ui {
-    class LeaveDialog;
-}
-
-class LeaveDialog : public QDialog
+/*!
+ * Single purpose QListWidget with unified item sizes (based on the
+ * biggest item) and showing rows x columns items.
+ *
+ * \note It expects that items aren't ever changed after show().
+ */
+class ListWidget : public QListWidget
 {
-    Q_OBJECT
-
 public:
-    explicit LeaveDialog(QWidget *parent = 0);
-    ~LeaveDialog();
+    ListWidget(QWidget * parent = nullptr);
+    void setRows(int rows);
+    void setColumns(int columns);
 
 protected:
-    virtual void resizeEvent(QResizeEvent* event) override;
+    virtual QSize viewportSizeHint() const override;
 
 private:
-    Ui::LeaveDialog *ui;
-    // LXQt::Power is used to know if the actions are doable, while
-    // LXQt::PowerManager is used to trigger the actions, while
-    // obeying the user option to ask or not for confirmation
-    LXQt::Power *mPower;
-    LXQt::PowerManager *mPowerManager;
-    LXQt::ScreenSaver *mScreensaver;
+    int mRows;
+    int mColumns;
 };
-
-
-#endif

--- a/lxqt-session/src/UdevNotifier.cpp
+++ b/lxqt-session/src/UdevNotifier.cpp
@@ -75,7 +75,7 @@ UdevNotifier::~UdevNotifier()
     udev_unref(d->udev);
 }
 
-void UdevNotifier::eventReady(int socket)
+void UdevNotifier::eventReady(int /*socket*/)
 {
     struct udev_device * dev;
     while (nullptr != (dev = udev_monitor_receive_device(d->monitor)))

--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -277,7 +277,7 @@ void LXQtModuleManager::startConfUpdate()
     startProcess(desktop);
 }
 
-void LXQtModuleManager::restartModules(int exitCode, QProcess::ExitStatus exitStatus)
+void LXQtModuleManager::restartModules(int /*exitCode*/, QProcess::ExitStatus exitStatus)
 {
     LXQtModule* proc = qobject_cast<LXQtModule*>(sender());
     if (nullptr == proc) {
@@ -396,7 +396,7 @@ void LXQtModuleManager::resetCrashReport()
     mCrashReport.clear();
 }
 
-bool LXQtModuleManager::nativeEventFilter(const QByteArray & eventType, void * message, long * result)
+bool LXQtModuleManager::nativeEventFilter(const QByteArray & eventType, void * /*message*/, long * /*result*/)
 {
     if (eventType != "xcb_generic_event_t") // We only want to handle XCB events
         return false;

--- a/lxqt-session/src/numlock.cpp
+++ b/lxqt-session/src/numlock.cpp
@@ -38,7 +38,7 @@
 
 /* the XKB stuff is based on code created by Oswald Buddenhagen <ossi@kde.org> */
 
-static unsigned int xkb_mask_modifier(Display* dpy, XkbDescPtr xkb, const char *name )
+static unsigned int xkb_mask_modifier(Display* /*dpy*/, XkbDescPtr xkb, const char *name )
 {
     int i;
     if( !xkb || !xkb->names )

--- a/lxqt-session/src/wmselectdialog.cpp
+++ b/lxqt-session/src/wmselectdialog.cpp
@@ -107,7 +107,7 @@ void WmSelectDialog::addWindowManager(const WindowManager &wm)
 }
 
 
-void WmSelectDialog::selectFileDialog(const QModelIndex &index)
+void WmSelectDialog::selectFileDialog(const QModelIndex &/*index*/)
 {
     QTreeWidget *wmList = ui->wmList;
     QTreeWidgetItem *item = wmList->currentItem();
@@ -130,7 +130,7 @@ void WmSelectDialog::selectFileDialog(const QModelIndex &index)
     ui->wmList->setCurrentItem(wmItem);
 }
 
-void WmSelectDialog::changeBtnStatus(const QModelIndex &index)
+void WmSelectDialog::changeBtnStatus(const QModelIndex &/*index*/)
 {
     QString wm = windowManager();
     ui->buttonBox->setEnabled(!wm.isEmpty() && findProgram(wm));


### PR DESCRIPTION
By use of "standalone" buttons there was no easy way to navigate
through the buttons with up/down/left/right keys. All homemade key
filtering techniques could be considered as "fragile" (mixing
definition in .ui with some logic estimations in .cpp).

Using a QListView/Widget seems to be more robust way -> let the Qt do
the navigation job.

This is a more polished #95 

closes lxde/lxqt#1183