### PR TITLE
lxqt-session: Provide reboot/powerOff methods

### DIFF
--- a/lxqt-session/src/lxqtmodman.cpp
+++ b/lxqt-session/src/lxqtmodman.cpp
@@ -347,7 +347,7 @@ LXQtModuleManager::~LXQtModuleManager()
 /**
 * @brief this logs us out by terminating our session
 **/
-void LXQtModuleManager::logout()
+void LXQtModuleManager::logout(bool doExit)
 {
     // modules
     ModulesMapIterator i(mNameMap);
@@ -377,7 +377,8 @@ void LXQtModuleManager::logout()
         mWmProcess->kill();
     }
 
-    QCoreApplication::exit(0);
+    if (doExit)
+        QCoreApplication::exit(0);
 }
 
 QString LXQtModuleManager::showWmSelectDialog()

--- a/lxqt-session/src/lxqtmodman.h
+++ b/lxqt-session/src/lxqtmodman.h
@@ -96,7 +96,7 @@ public slots:
     gracefully (to kill it if it is not possible). Then the session
     exits - it returns to the kdm/gdm in most cases.
     */
-    void logout();
+    void logout(bool doExit);
 
 signals:
     void moduleStateChanged(QString moduleName, bool state);

--- a/lxqt-session/src/sessionapplication.cpp
+++ b/lxqt-session/src/sessionapplication.cpp
@@ -61,7 +61,7 @@ SessionApplication::SessionApplication(int& argc, char** argv) :
     qputenv("LXQT_SESSION_CONFIG", configName.toLocal8Bit());
 
     modman = new LXQtModuleManager(winmanager);
-    connect(this, &LXQt::Application::unixSignal, modman, &LXQtModuleManager::logout);
+    connect(this, &LXQt::Application::unixSignal, modman, [this] { modman->logout(true); });
     new SessionDBusAdaptor(modman);
     // connect to D-Bus and register as an object:
     QDBusConnection::sessionBus().registerService("org.lxqt.session");


### PR DESCRIPTION
By providing the reboot/powerOff mehotds we are trying to terminate the
running processes/modules in prefered order (the logout procedure should
know how to do it). After that invoke the particular reboot/shutdown.

W/o the logout before reboot/shutdown the reboot/shutdown provider
(namely systemd) was terminating all proceses in undefined (random?)
order which could lead to insane shutdown and/or deadlocks with poorly
written applications/libraries.

This needs lxde/liblxqt#123 and supersedes lxde/liblxqt#121

closes lxde/lxqt#1311