### PR TITLE
install session configs in /usr/share/lxqt

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -3,7 +3,7 @@ install(FILES
     lxqt.conf
     session.conf
     windowmanagers.conf
-    DESTINATION "${LXQT_ETC_XDG_DIR}/lxqt"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/lxqt"
     COMPONENT Runtime
 )
 install(DIRECTORY openbox


### PR DESCRIPTION
move lxqt session configuration from /etc/xdg/lxqt to /usr/share/xdg

this will give distributions the chance to provide their configs without pain