### PR TITLE
cmake: Handle CMP0063

### DIFF
--- a/autostart/CMakeLists.txt
+++ b/autostart/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
-
 file(GLOB DESKTOP_FILES_IN *.desktop.in)
 
 # Translations **********************************

--- a/lxqt-config-session/CMakeLists.txt
+++ b/lxqt-config-session/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(lxqt-config-session)
+set(LXQT_CONFIG_SESSION_PROJECT_NAME "lxqt-config-session")
 
 
 set(lxqt-sessioncfg_HDRS
@@ -48,7 +48,7 @@ lxqt_translate_ts(lxqt-sessioncfg_QM_FILES
         ${lxqt-sessioncfg_SRCS}
         ${lxqt-sessioncfg_UI_FILES}
     INSTALL_DIR
-        "${LXQT_TRANSLATIONS_DIR}/${PROJECT_NAME}"
+        "${LXQT_TRANSLATIONS_DIR}/${LXQT_CONFIG_SESSION_PROJECT_NAME}"
     PULL_TRANSLATIONS
         ${PULL_TRANSLATIONS}
     CLEAN_TRANSLATIONS
@@ -58,10 +58,10 @@ lxqt_translate_ts(lxqt-sessioncfg_QM_FILES
     TRANSLATIONS_REFSPEC
         ${TRANSLATIONS_REFSPEC}
     REPO_SUBDIR
-        "lxqt-session/${PROJECT_NAME}"
+        "lxqt-session/${LXQT_CONFIG_SESSION_PROJECT_NAME}"
 )
 
-lxqt_app_translation_loader(lxqt-sessioncfg_QM_LOADER ${PROJECT_NAME})
+lxqt_app_translation_loader(lxqt-sessioncfg_QM_LOADER ${LXQT_CONFIG_SESSION_PROJECT_NAME})
 lxqt_translate_desktop(lxqt-sessioncfg_DESKTOP_FILES SOURCES lxqt-config-session.desktop.in)
 
 add_executable(lxqt-config-session

--- a/lxqt-leave/CMakeLists.txt
+++ b/lxqt-leave/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(lxqt-leave)
+set(LXQT_LEAVE_PROJECT_NAME "lxqt-leave")
 
 set(CPP_FILES
     main.cpp
@@ -36,7 +36,7 @@ lxqt_translate_ts(lxqt-leave_QM_FILES
         ${UI_FILES}
         ${H_FILES}
     INSTALL_DIR
-        "${LXQT_TRANSLATIONS_DIR}/${PROJECT_NAME}"
+        "${LXQT_TRANSLATIONS_DIR}/${LXQT_LEAVE_PROJECT_NAME}"
     PULL_TRANSLATIONS
         ${PULL_TRANSLATIONS}
     CLEAN_TRANSLATIONS
@@ -46,10 +46,10 @@ lxqt_translate_ts(lxqt-leave_QM_FILES
     TRANSLATIONS_REFSPEC
         ${TRANSLATIONS_REFSPEC}
     REPO_SUBDIR
-        "lxqt-session/${PROJECT_NAME}"
+        "lxqt-session/${LXQT_LEAVE_PROJECT_NAME}"
 )
 
-lxqt_app_translation_loader(lxqt-leave_QM_LOADER ${PROJECT_NAME})
+lxqt_app_translation_loader(lxqt-leave_QM_LOADER ${LXQT_LEAVE_PROJECT_NAME})
 #************************************************
 
 

--- a/lxqt-session/CMakeLists.txt
+++ b/lxqt-session/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
-project(lxqt-session)
+set(LXQT_SESSION_PROJECT_NAME "lxqt-session")
 
 if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE Release)
@@ -47,7 +46,7 @@ lxqt_translate_ts(lxqt-session_QM_FILES
         ${lxqt-session_SRCS}
         ${lxqt-session_UI}
     INSTALL_DIR
-        "${LXQT_TRANSLATIONS_DIR}/${PROJECT_NAME}"
+        "${LXQT_TRANSLATIONS_DIR}/${LXQT_SESSION_PROJECT_NAME}"
     PULL_TRANSLATIONS
         ${PULL_TRANSLATIONS}
     CLEAN_TRANSLATIONS
@@ -57,9 +56,9 @@ lxqt_translate_ts(lxqt-session_QM_FILES
     TRANSLATIONS_REFSPEC
         ${TRANSLATIONS_REFSPEC}
     REPO_SUBDIR
-        "lxqt-session/${PROJECT_NAME}"
+        "lxqt-session/${LXQT_SESSION_PROJECT_NAME}"
 )
-lxqt_app_translation_loader(lxqt-session_QM_LOADER ${PROJECT_NAME})
+lxqt_app_translation_loader(lxqt-session_QM_LOADER ${LXQT_SESSION_PROJECT_NAME})
 
 add_executable(lxqt-session
     ${lxqt-session_SRCS}


### PR DESCRIPTION
Honor visibility properties for all target types.
The culprit here are the different CMake projects declared. It resets the
properties.
CMake minimum requirements are no longer needed. It's defined in the top
top CMakeLists.txt.